### PR TITLE
Switched to locally scoped partitioning for MPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "build-probe-mpi"
 version = "0.1.1"
-source = "git+https://github.com/rsmpi/rsmpi?rev=e9b1844#e9b18441bb967862f46f853b4d5ffda8f5c55b33"
+source = "git+https://github.com/rsmpi/rsmpi?rev=70591e6#70591e68b6c731c2d7ec09b6d02013de00c75446"
 dependencies = [
  "pkg-config",
 ]
@@ -807,9 +807,9 @@ dependencies = [
 [[package]]
 name = "mpi"
 version = "0.6.0"
-source = "git+https://github.com/rsmpi/rsmpi?rev=e9b1844#e9b18441bb967862f46f853b4d5ffda8f5c55b33"
+source = "git+https://github.com/rsmpi/rsmpi?rev=70591e6#70591e68b6c731c2d7ec09b6d02013de00c75446"
 dependencies = [
- "build-probe-mpi 0.1.1 (git+https://github.com/rsmpi/rsmpi?rev=e9b1844)",
+ "build-probe-mpi 0.1.1 (git+https://github.com/rsmpi/rsmpi?rev=70591e6)",
  "conv",
  "memoffset",
  "mpi-derive",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "mpi-derive"
 version = "0.1.0"
-source = "git+https://github.com/rsmpi/rsmpi?rev=e9b1844#e9b18441bb967862f46f853b4d5ffda8f5c55b33"
+source = "git+https://github.com/rsmpi/rsmpi?rev=70591e6#70591e68b6c731c2d7ec09b6d02013de00c75446"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -831,10 +831,10 @@ dependencies = [
 [[package]]
 name = "mpi-sys"
 version = "0.2.0"
-source = "git+https://github.com/rsmpi/rsmpi?rev=e9b1844#e9b18441bb967862f46f853b4d5ffda8f5c55b33"
+source = "git+https://github.com/rsmpi/rsmpi?rev=70591e6#70591e68b6c731c2d7ec09b6d02013de00c75446"
 dependencies = [
  "bindgen 0.55.1",
- "build-probe-mpi 0.1.1 (git+https://github.com/rsmpi/rsmpi?rev=e9b1844)",
+ "build-probe-mpi 0.1.1 (git+https://github.com/rsmpi/rsmpi?rev=70591e6)",
  "cc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "humantime-serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
+dependencies = [
+ "humantime 2.1.0",
+ "serde",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +944,7 @@ dependencies = [
  "anyhow",
  "build-probe-mpi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "contracts",
+ "humantime-serde",
  "memoffset",
  "mpi",
  "necsim-core",

--- a/docs/simulate.ron
+++ b/docs/simulate.ron
@@ -593,6 +593,12 @@
             /* explicit size of the MPI universe, must match the MPI universe */
             /* optional, dynamic default = MPI's world size */
             world: (1 < u32),
+            /* minimum time interval between migration messages */
+            /* optional, default = "100ms" */
+            migration: (DurationString),
+            /* minimum time interval between progress messages */
+            /* optional, default = "100ms" */
+            progress: (DurationString),
         )
     ),
 

--- a/docs/simulate.ron
+++ b/docs/simulate.ron
@@ -149,7 +149,8 @@
     /* selection of the initialisation of the random number generator */
     rng: (
         /* seeds from OS-provided randomness */
-        /* infallible (unless the OS malfunctions) */
+        /* forbidden for partitioned simulations,
+         *  infallible for monolithic ones (unless the OS malfunctions) */
       | Entropy
         /* seeds based on the given 64bit seed */
         /* infallible */

--- a/docs/simulate.ron
+++ b/docs/simulate.ron
@@ -149,8 +149,8 @@
     /* selection of the initialisation of the random number generator */
     rng: (
         /* seeds from OS-provided randomness */
-        /* forbidden for partitioned simulations,
-         *  infallible for monolithic ones (unless the OS malfunctions) */
+        /* forbidden for partitioned simulations */
+        /* infallible for monolithic simulations (unless the OS malfunctions) */
       | Entropy
         /* seeds based on the given 64bit seed */
         /* infallible */

--- a/necsim/core/src/reporter/filter.rs
+++ b/necsim/core/src/reporter/filter.rs
@@ -38,7 +38,7 @@ impl<R: Reporter, KeepSpeciation: Boolean, KeepDispersal: Boolean, KeepProgress:
     fn from(reporter: R) -> Self {
         Self {
             reporter,
-            marker: PhantomData,
+            marker: PhantomData::<(KeepSpeciation, KeepDispersal, KeepProgress)>,
         }
     }
 }

--- a/necsim/core/src/reporter/used.rs
+++ b/necsim/core/src/reporter/used.rs
@@ -22,7 +22,7 @@ impl<T, B: Boolean> From<T> for MaybeUsed<T, B> {
     fn from(inner: T) -> Self {
         Self {
             inner,
-            _used: PhantomData,
+            _used: PhantomData::<B>,
         }
     }
 }

--- a/necsim/impls/cuda/src/cogs/rng.rs
+++ b/necsim/impls/cuda/src/cogs/rng.rs
@@ -18,7 +18,7 @@ impl<M: MathsCore, R: RngCore<M> + StackOnly + TypeLayout> Clone for CudaRng<M, 
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            marker: PhantomData,
+            marker: PhantomData::<M>,
         }
     }
 }
@@ -29,7 +29,7 @@ impl<M: MathsCore, R: RngCore<M> + StackOnly + TypeLayout> From<R> for CudaRng<M
     fn from(rng: R) -> Self {
         Self {
             inner: rng,
-            marker: PhantomData,
+            marker: PhantomData::<M>,
         }
     }
 }
@@ -49,7 +49,7 @@ impl<M: MathsCore, R: RngCore<M> + StackOnly + TypeLayout> RngCore<M> for CudaRn
     fn from_seed(seed: Self::Seed) -> Self {
         Self {
             inner: R::from_seed(seed),
-            marker: PhantomData,
+            marker: PhantomData::<M>,
         }
     }
 
@@ -79,7 +79,7 @@ impl<'de, M: MathsCore, R: RngCore<M> + StackOnly + TypeLayout> Deserialize<'de>
 
         Ok(Self {
             inner,
-            marker: PhantomData,
+            marker: PhantomData::<M>,
         })
     }
 }

--- a/necsim/impls/no-std/src/parallelisation/independent/individuals.rs
+++ b/necsim/impls/no-std/src/parallelisation/independent/individuals.rs
@@ -36,6 +36,7 @@ use super::{reporter::IgnoreProgressReporterProxy, DedupCache};
 
 #[allow(clippy::type_complexity)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     G: PrimeableRng<M>,
@@ -57,7 +58,7 @@ pub fn simulate<
         NeverImmigrationEntry,
     >,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     L: IntoIterator<Item = Lineage>,
 >(
     simulation: &mut Simulation<

--- a/necsim/impls/no-std/src/parallelisation/independent/landscape.rs
+++ b/necsim/impls/no-std/src/parallelisation/independent/landscape.rs
@@ -39,6 +39,7 @@ use super::{reporter::IgnoreProgressReporterProxy, DedupCache};
 
 #[allow(clippy::type_complexity)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     C: Decomposition<M, H>,
@@ -62,7 +63,7 @@ pub fn simulate<
         NeverImmigrationEntry,
     >,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     L: IntoIterator<Item = Lineage>,
 >(
     simulation: &mut Simulation<

--- a/necsim/impls/no-std/src/parallelisation/independent/monolithic/mod.rs
+++ b/necsim/impls/no-std/src/parallelisation/independent/monolithic/mod.rs
@@ -41,6 +41,7 @@ use reporter::{
 
 #[allow(clippy::type_complexity, clippy::too_many_lines)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     G: PrimeableRng<M>,
@@ -62,7 +63,7 @@ pub fn simulate<
         NeverImmigrationEntry,
     >,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     L: IntoIterator<Item = Lineage>,
 >(
     simulation: &mut Simulation<

--- a/necsim/impls/no-std/src/parallelisation/independent/monolithic/reporter/mod.rs
+++ b/necsim/impls/no-std/src/parallelisation/independent/monolithic/reporter/mod.rs
@@ -13,7 +13,7 @@ mod recorded;
 #[allow(clippy::inline_always, clippy::inline_fn_without_body)]
 #[allow(clippy::no_effect_underscore_binding)]
 #[contract_trait]
-pub trait WaterLevelReporterProxy<'p, R: Reporter, P: LocalPartition<R>>:
+pub trait WaterLevelReporterProxy<'l, 'p, R: Reporter, P: LocalPartition<'p, R>>:
     Sized
     + Reporter<
         ReportSpeciation = R::ReportSpeciation,
@@ -21,7 +21,7 @@ pub trait WaterLevelReporterProxy<'p, R: Reporter, P: LocalPartition<R>>:
         ReportProgress = False,
     >
 {
-    fn new(capacity: usize, local_partition: &'p mut P) -> Self;
+    fn new(capacity: usize, local_partition: &'l mut P) -> Self;
 
     fn water_level(&self) -> NonNegativeF64;
 
@@ -36,23 +36,24 @@ pub trait WaterLevelReporterProxy<'p, R: Reporter, P: LocalPartition<R>>:
 pub enum WaterLevelReporterStrategy {}
 
 pub trait WaterLevelReporterConstructor<
+    'l,
     'p,
     IsLive: Boolean,
     R: Reporter,
-    P: 'p + LocalPartition<R, IsLive = IsLive>,
+    P: 'l + LocalPartition<'p, R, IsLive = IsLive>,
 >
 {
-    type WaterLevelReporter: WaterLevelReporterProxy<'p, R, P>;
+    type WaterLevelReporter: WaterLevelReporterProxy<'l, 'p, R, P>;
 }
 
-impl<'p, IsLive: Boolean, R: Reporter, P: 'p + LocalPartition<R, IsLive = IsLive>>
-    WaterLevelReporterConstructor<'p, IsLive, R, P> for WaterLevelReporterStrategy
+impl<'l, 'p, IsLive: Boolean, R: Reporter, P: 'l + LocalPartition<'p, R, IsLive = IsLive>>
+    WaterLevelReporterConstructor<'l, 'p, IsLive, R, P> for WaterLevelReporterStrategy
 {
-    default type WaterLevelReporter = live::LiveWaterLevelReporterProxy<'p, R, P>;
+    default type WaterLevelReporter = live::LiveWaterLevelReporterProxy<'l, 'p, R, P>;
 }
 
-impl<'p, R: Reporter, P: 'p + LocalPartition<R, IsLive = False>>
-    WaterLevelReporterConstructor<'p, False, R, P> for WaterLevelReporterStrategy
+impl<'l, 'p, R: Reporter, P: 'l + LocalPartition<'p, R, IsLive = False>>
+    WaterLevelReporterConstructor<'l, 'p, False, R, P> for WaterLevelReporterStrategy
 {
-    type WaterLevelReporter = recorded::RecordedWaterLevelReporterProxy<'p, R, P>;
+    type WaterLevelReporter = recorded::RecordedWaterLevelReporterProxy<'l, 'p, R, P>;
 }

--- a/necsim/impls/no-std/src/parallelisation/independent/monolithic/reporter/recorded.rs
+++ b/necsim/impls/no-std/src/parallelisation/independent/monolithic/reporter/recorded.rs
@@ -8,15 +8,15 @@ use necsim_partitioning_core::LocalPartition;
 use super::WaterLevelReporterProxy;
 
 #[allow(clippy::module_name_repetitions)]
-pub struct RecordedWaterLevelReporterProxy<'p, R: Reporter, P: LocalPartition<R>> {
+pub struct RecordedWaterLevelReporterProxy<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> {
     water_level: NonNegativeF64,
 
-    local_partition: &'p mut P,
-    _marker: PhantomData<R>,
+    local_partition: &'l mut P,
+    _marker: PhantomData<(&'p (), R)>,
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> fmt::Debug
-    for RecordedWaterLevelReporterProxy<'p, R, P>
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> fmt::Debug
+    for RecordedWaterLevelReporterProxy<'l, 'p, R, P>
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         struct EventBufferLen(usize);
@@ -33,7 +33,9 @@ impl<'p, R: Reporter, P: LocalPartition<R>> fmt::Debug
     }
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> Reporter for RecordedWaterLevelReporterProxy<'p, R, P> {
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> Reporter
+    for RecordedWaterLevelReporterProxy<'l, 'p, R, P>
+{
     impl_report!(speciation(&mut self, speciation: MaybeUsed<R::ReportSpeciation>) {
         self.local_partition.get_reporter().report_speciation(speciation.into());
     });
@@ -46,17 +48,17 @@ impl<'p, R: Reporter, P: LocalPartition<R>> Reporter for RecordedWaterLevelRepor
 }
 
 #[contract_trait]
-impl<'p, R: Reporter, P: LocalPartition<R>> WaterLevelReporterProxy<'p, R, P>
-    for RecordedWaterLevelReporterProxy<'p, R, P>
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> WaterLevelReporterProxy<'l, 'p, R, P>
+    for RecordedWaterLevelReporterProxy<'l, 'p, R, P>
 {
-    fn new(_capacity: usize, local_partition: &'p mut P) -> Self {
+    fn new(_capacity: usize, local_partition: &'l mut P) -> Self {
         info!("Events will be reported using the recorded water-level algorithm ...");
 
         Self {
             water_level: NonNegativeF64::zero(),
 
             local_partition,
-            _marker: PhantomData::<R>,
+            _marker: PhantomData::<(&'p (), R)>,
         }
     }
 

--- a/necsim/impls/no-std/src/parallelisation/independent/reporter.rs
+++ b/necsim/impls/no-std/src/parallelisation/independent/reporter.rs
@@ -4,27 +4,31 @@ use necsim_core::{impl_report, reporter::Reporter};
 
 use necsim_partitioning_core::LocalPartition;
 
-pub struct IgnoreProgressReporterProxy<'p, R: Reporter, P: LocalPartition<R>> {
-    local_partition: &'p mut P,
-    _marker: PhantomData<R>,
+pub struct IgnoreProgressReporterProxy<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> {
+    local_partition: &'l mut P,
+    _marker: PhantomData<(&'p (), R)>,
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> fmt::Debug for IgnoreProgressReporterProxy<'p, R, P> {
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> fmt::Debug
+    for IgnoreProgressReporterProxy<'l, 'p, R, P>
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct(stringify!(IgnoreProgressReporterProxy))
             .finish()
     }
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> Reporter for IgnoreProgressReporterProxy<'p, R, P> {
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> Reporter
+    for IgnoreProgressReporterProxy<'l, 'p, R, P>
+{
     impl_report!(speciation(&mut self, speciation: MaybeUsed<
-        <<P as LocalPartition<R>>::Reporter as Reporter
+        <<P as LocalPartition<'p, R>>::Reporter as Reporter
     >::ReportSpeciation>) {
         self.local_partition.get_reporter().report_speciation(speciation.into());
     });
 
     impl_report!(dispersal(&mut self, dispersal: MaybeUsed<
-        <<P as LocalPartition<R>>::Reporter as Reporter
+        <<P as LocalPartition<'p, R>>::Reporter as Reporter
     >::ReportDispersal>) {
         self.local_partition.get_reporter().report_dispersal(dispersal.into());
     });
@@ -32,11 +36,11 @@ impl<'p, R: Reporter, P: LocalPartition<R>> Reporter for IgnoreProgressReporterP
     impl_report!(progress(&mut self, _progress: Ignored) {});
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> IgnoreProgressReporterProxy<'p, R, P> {
-    pub fn from(local_partition: &'p mut P) -> Self {
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> IgnoreProgressReporterProxy<'l, 'p, R, P> {
+    pub fn from(local_partition: &'l mut P) -> Self {
         Self {
             local_partition,
-            _marker: PhantomData::<R>,
+            _marker: PhantomData::<(&'p (), R)>,
         }
     }
 

--- a/necsim/impls/no-std/src/parallelisation/monolithic/averaging.rs
+++ b/necsim/impls/no-std/src/parallelisation/monolithic/averaging.rs
@@ -24,6 +24,7 @@ use crate::{
 
 #[allow(clippy::type_complexity)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     G: RngCore<M>,
@@ -50,7 +51,7 @@ pub fn simulate<
         BufferedImmigrationEntry,
     >,
     P: Reporter,
-    L: LocalPartition<P>,
+    L: LocalPartition<'p, P>,
 >(
     simulation: &mut Simulation<
         M,

--- a/necsim/impls/no-std/src/parallelisation/monolithic/lockstep.rs
+++ b/necsim/impls/no-std/src/parallelisation/monolithic/lockstep.rs
@@ -24,6 +24,7 @@ use crate::{
 
 #[allow(clippy::type_complexity)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     G: RngCore<M>,
@@ -50,7 +51,7 @@ pub fn simulate<
         BufferedImmigrationEntry,
     >,
     P: Reporter,
-    L: LocalPartition<P>,
+    L: LocalPartition<'p, P>,
 >(
     simulation: &mut Simulation<
         M,

--- a/necsim/impls/no-std/src/parallelisation/monolithic/monolithic.rs
+++ b/necsim/impls/no-std/src/parallelisation/monolithic/monolithic.rs
@@ -23,6 +23,7 @@ use crate::{
 
 #[allow(clippy::type_complexity)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     G: RngCore<M>,
@@ -35,7 +36,7 @@ pub fn simulate<
     E: EventSampler<M, H, G, R, S, NeverEmigrationExit, D, C, T, N>,
     A: ActiveLineageSampler<M, H, G, R, S, NeverEmigrationExit, D, C, T, N, E, NeverImmigrationEntry>,
     P: Reporter,
-    L: LocalPartition<P>,
+    L: LocalPartition<'p, P>,
 >(
     simulation: &mut Simulation<
         M,

--- a/necsim/impls/no-std/src/parallelisation/monolithic/optimistic.rs
+++ b/necsim/impls/no-std/src/parallelisation/monolithic/optimistic.rs
@@ -28,6 +28,7 @@ use super::reporter::BufferingReporterProxy;
 
 #[allow(clippy::type_complexity)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     G: RngCore<M>,
@@ -54,7 +55,7 @@ pub fn simulate<
         BufferedImmigrationEntry,
     >,
     P: Reporter,
-    L: LocalPartition<P>,
+    L: LocalPartition<'p, P>,
 >(
     simulation: &mut Simulation<
         M,

--- a/necsim/impls/no-std/src/parallelisation/monolithic/optimistic_lockstep.rs
+++ b/necsim/impls/no-std/src/parallelisation/monolithic/optimistic_lockstep.rs
@@ -24,6 +24,7 @@ use crate::{
 
 #[allow(clippy::type_complexity)]
 pub fn simulate<
+    'p,
     M: MathsCore,
     H: Habitat<M>,
     G: RngCore<M>,
@@ -50,7 +51,7 @@ pub fn simulate<
         BufferedImmigrationEntry,
     >,
     P: Reporter,
-    L: LocalPartition<P>,
+    L: LocalPartition<'p, P>,
 >(
     simulation: &mut Simulation<
         M,

--- a/necsim/impls/no-std/src/parallelisation/monolithic/reporter.rs
+++ b/necsim/impls/no-std/src/parallelisation/monolithic/reporter.rs
@@ -9,13 +9,15 @@ use necsim_core::{
 
 use necsim_partitioning_core::LocalPartition;
 
-pub struct BufferingReporterProxy<'p, R: Reporter, P: LocalPartition<R>> {
-    local_partition: &'p mut P,
+pub struct BufferingReporterProxy<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> {
+    local_partition: &'l mut P,
     event_buffer: Vec<PackedEvent>,
-    _marker: PhantomData<R>,
+    _marker: PhantomData<(&'p (), R)>,
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> fmt::Debug for BufferingReporterProxy<'p, R, P> {
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> fmt::Debug
+    for BufferingReporterProxy<'l, 'p, R, P>
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         struct EventBufferLen(usize);
 
@@ -31,32 +33,34 @@ impl<'p, R: Reporter, P: LocalPartition<R>> fmt::Debug for BufferingReporterProx
     }
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> Reporter for BufferingReporterProxy<'p, R, P> {
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> Reporter
+    for BufferingReporterProxy<'l, 'p, R, P>
+{
     impl_report!(speciation(&mut self, speciation: MaybeUsed<
-        <<P as LocalPartition<R>>::Reporter as Reporter
+        <<P as LocalPartition<'p, R>>::Reporter as Reporter
     >::ReportSpeciation>) {
         self.event_buffer.push(speciation.clone().into());
     });
 
     impl_report!(dispersal(&mut self, dispersal: MaybeUsed<
-        <<P as LocalPartition<R>>::Reporter as Reporter
+        <<P as LocalPartition<'p, R>>::Reporter as Reporter
     >::ReportDispersal>) {
         self.event_buffer.push(dispersal.clone().into());
     });
 
     impl_report!(progress(&mut self, progress: MaybeUsed<
-        <<P as LocalPartition<R>>::Reporter as Reporter
+        <<P as LocalPartition<'p, R>>::Reporter as Reporter
     >::ReportProgress>) {
         self.local_partition.get_reporter().report_progress(progress.into());
     });
 }
 
-impl<'p, R: Reporter, P: LocalPartition<R>> BufferingReporterProxy<'p, R, P> {
-    pub fn from(local_partition: &'p mut P) -> Self {
+impl<'l, 'p, R: Reporter, P: LocalPartition<'p, R>> BufferingReporterProxy<'l, 'p, R, P> {
+    pub fn from(local_partition: &'l mut P) -> Self {
         Self {
             local_partition,
             event_buffer: Vec::new(),
-            _marker: PhantomData::<R>,
+            _marker: PhantomData::<(&'p (), R)>,
         }
     }
 

--- a/necsim/partitioning/monolithic/src/live.rs
+++ b/necsim/partitioning/monolithic/src/live.rs
@@ -35,9 +35,10 @@ impl<R: Reporter> fmt::Debug for LiveMonolithicLocalPartition<R> {
 }
 
 #[contract_trait]
-impl<R: Reporter> LocalPartition<R> for LiveMonolithicLocalPartition<R> {
+impl<'p, R: Reporter> LocalPartition<'p, R> for LiveMonolithicLocalPartition<R> {
     type ImmigrantIterator<'a>
     where
+        'p: 'a,
         R: 'a,
     = ImmigrantPopIterator<'a>;
     type IsLive = True;
@@ -55,12 +56,15 @@ impl<R: Reporter> LocalPartition<R> for LiveMonolithicLocalPartition<R> {
         Partition::monolithic()
     }
 
-    fn migrate_individuals<E: Iterator<Item = (u32, MigratingLineage)>>(
-        &mut self,
+    fn migrate_individuals<'a, E: Iterator<Item = (u32, MigratingLineage)>>(
+        &'a mut self,
         emigrants: &mut E,
         _emigration_mode: MigrationMode,
         _immigration_mode: MigrationMode,
-    ) -> Self::ImmigrantIterator<'_> {
+    ) -> Self::ImmigrantIterator<'a>
+    where
+        'p: 'a,
+    {
         for (_, emigrant) in emigrants {
             self.loopback.push(emigrant);
         }

--- a/necsim/partitioning/monolithic/src/recorded.rs
+++ b/necsim/partitioning/monolithic/src/recorded.rs
@@ -45,9 +45,10 @@ impl<R: Reporter> fmt::Debug for RecordedMonolithicLocalPartition<R> {
 }
 
 #[contract_trait]
-impl<R: Reporter> LocalPartition<R> for RecordedMonolithicLocalPartition<R> {
+impl<'p, R: Reporter> LocalPartition<'p, R> for RecordedMonolithicLocalPartition<R> {
     type ImmigrantIterator<'a>
     where
+        'p: 'a,
         R: 'a,
     = ImmigrantPopIterator<'a>;
     type IsLive = False;
@@ -65,12 +66,15 @@ impl<R: Reporter> LocalPartition<R> for RecordedMonolithicLocalPartition<R> {
         Partition::monolithic()
     }
 
-    fn migrate_individuals<E: Iterator<Item = (u32, MigratingLineage)>>(
-        &mut self,
+    fn migrate_individuals<'a, E: Iterator<Item = (u32, MigratingLineage)>>(
+        &'a mut self,
         emigrants: &mut E,
         _emigration_mode: MigrationMode,
         _immigration_mode: MigrationMode,
-    ) -> Self::ImmigrantIterator<'_> {
+    ) -> Self::ImmigrantIterator<'a>
+    where
+        'p: 'a,
+    {
         for (_, emigrant) in emigrants {
             self.loopback.push(emigrant);
         }

--- a/necsim/partitioning/mpi/Cargo.toml
+++ b/necsim/partitioning/mpi/Cargo.toml
@@ -21,6 +21,7 @@ memoffset = "0.6"
 serde = "1.0"
 serde_state = "0.4"
 serde_derive_state = "0.4"
+humantime-serde = "1.0"
 
 [build-dependencies]
 build-probe-mpi = "0.1"

--- a/necsim/partitioning/mpi/Cargo.toml
+++ b/necsim/partitioning/mpi/Cargo.toml
@@ -14,7 +14,7 @@ necsim-impls-std = { path = "../../impls/std" }
 necsim-partitioning-core = { path = "../../partitioning/core" }
 
 contracts = { git = "https://gitlab.com/MomoLangenstein/contracts", rev = "3a44375a" }
-mpi = { git = "https://github.com/rsmpi/rsmpi", rev = "e9b1844", default-features = false, features = ["derive"] }
+mpi = { git = "https://github.com/rsmpi/rsmpi", rev = "70591e6", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 anyhow = "1.0"
 memoffset = "0.6"

--- a/necsim/partitioning/mpi/src/lib.rs
+++ b/necsim/partitioning/mpi/src/lib.rs
@@ -4,12 +4,12 @@
 #[macro_use]
 extern crate contracts;
 
-use std::{fmt, mem::ManuallyDrop, num::NonZeroU32};
+use std::{fmt, mem::ManuallyDrop, num::NonZeroU32, time::Duration};
 
 use anyhow::Context;
+use humantime_serde::re::humantime::format_duration;
 use mpi::{
     environment::Universe,
-    request::LocalScope,
     topology::{Communicator, Rank, SystemCommunicator},
     Tag,
 };
@@ -24,8 +24,10 @@ use necsim_impls_std::event_log::recorder::EventLogRecorder;
 use necsim_partitioning_core::{context::ReporterContext, partition::Partition, Partitioning};
 
 mod partition;
+mod request;
 
 pub use partition::{MpiLocalPartition, MpiParallelPartition, MpiRootPartition};
+use request::{reduce_scope, DataOrRequest};
 
 #[derive(Error, Debug)]
 pub enum MpiPartitioningError {
@@ -46,38 +48,71 @@ pub enum MpiLocalPartitionError {
 pub struct MpiPartitioning {
     universe: ManuallyDrop<Universe>,
     world: SystemCommunicator,
+    migration_interval: Duration,
+    progress_interval: Duration,
 }
 
 impl fmt::Debug for MpiPartitioning {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        struct FormattedDuration(Duration);
+
+        impl fmt::Debug for FormattedDuration {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                fmt.write_str(&format_duration(self.0).to_string())
+            }
+        }
+
         fmt.debug_struct(stringify!(MpiPartitioning))
             .field("world", &self.get_partition().size().get())
+            .field(
+                "migration_interval",
+                &FormattedDuration(self.migration_interval),
+            )
+            .field(
+                "progress_interval",
+                &FormattedDuration(self.progress_interval),
+            )
             .finish()
     }
 }
 
 impl Serialize for MpiPartitioning {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut args = serializer.serialize_struct(stringify!(MpiPartitioning), 1)?;
+        let mut args = serializer.serialize_struct(stringify!(MpiPartitioning), 3)?;
         args.serialize_field("world", &self.get_partition().size())?;
+        args.serialize_field(
+            "migration",
+            &format_duration(self.migration_interval).to_string(),
+        )?;
+        args.serialize_field(
+            "progress",
+            &format_duration(self.progress_interval).to_string(),
+        )?;
         args.end()
     }
 }
 
 impl<'de> Deserialize<'de> for MpiPartitioning {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let partitioning = Self::initialise().map_err(serde::de::Error::custom)?;
+        let mut partitioning = Self::initialise().map_err(serde::de::Error::custom)?;
 
-        let _raw = MpiPartitioningRaw::deserialize_state(
+        let raw = MpiPartitioningRaw::deserialize_state(
             &mut partitioning.get_partition().size(),
             deserializer,
         )?;
+
+        partitioning.set_migration_interval(raw.migration_interval);
+        partitioning.set_progress_interval(raw.progress_interval);
 
         Ok(partitioning)
     }
 }
 
 impl MpiPartitioning {
+    #[doc(hidden)]
+    const MPI_DEFAULT_MIGRATION_INTERVAL: Duration = Duration::from_millis(100_u64);
+    #[doc(hidden)]
+    const MPI_DEFAULT_PROGRESS_INTERVAL: Duration = Duration::from_millis(100_u64);
     const MPI_MIGRATION_TAG: Tag = 1;
     const MPI_PROGRESS_TAG: Tag = 0;
     const ROOT_RANK: Rank = 0;
@@ -93,10 +128,23 @@ impl MpiPartitioning {
         let world = universe.world();
 
         if world.size() > 1 {
-            Ok(Self { universe, world })
+            Ok(Self {
+                universe,
+                world,
+                migration_interval: Self::MPI_DEFAULT_MIGRATION_INTERVAL,
+                progress_interval: Self::MPI_DEFAULT_PROGRESS_INTERVAL,
+            })
         } else {
             Err(MpiPartitioningError::NoParallelism)
         }
+    }
+
+    pub fn set_migration_interval(&mut self, migration_interval: Duration) {
+        self.migration_interval = migration_interval;
+    }
+
+    pub fn set_progress_interval(&mut self, progress_interval: Duration) {
+        self.progress_interval = progress_interval;
     }
 }
 
@@ -151,9 +199,7 @@ impl Partitioning for MpiPartitioning {
             .and_then(EventLogRecorder::assert_empty)
             .context(MpiLocalPartitionError::InvalidEventSubLog)?;
 
-        let mut mpi_local_continue = false;
-        let mut mpi_global_continue = false;
-
+        let mut mpi_local_global_continue = (false, false);
         let mut mpi_local_remaining = 0_u64;
 
         #[allow(clippy::cast_sign_loss)]
@@ -161,30 +207,38 @@ impl Partitioning for MpiPartitioning {
 
         let mut mpi_migration_buffers: Vec<Vec<MigratingLineage>> = Vec::with_capacity(world_size);
         mpi_migration_buffers.resize_with(world_size, Vec::new);
-        let mut mpi_migration_buffers = mpi_migration_buffers.into_boxed_slice();
 
         mpi::request::scope(|scope| {
+            let scope = reduce_scope(scope);
+
+            let mpi_local_global_continue =
+                DataOrRequest::new(&mut mpi_local_global_continue, scope);
+            let mpi_local_remaining = DataOrRequest::new(&mut mpi_local_remaining, scope);
+            let mpi_migration_buffers = mpi_migration_buffers
+                .iter_mut()
+                .map(|buffer| DataOrRequest::new(buffer, scope))
+                .collect::<Vec<_>>()
+                .into_boxed_slice();
+
             let local_partition = if self.world.rank() == MpiPartitioning::ROOT_RANK {
                 MpiLocalPartition::Root(Box::new(MpiRootPartition::new(
                     ManuallyDrop::into_inner(self.universe),
-                    self.world,
-                    reduce_scope(scope),
-                    &mut mpi_local_continue,
-                    &mut mpi_global_continue,
-                    &mut mpi_migration_buffers,
+                    mpi_local_global_continue,
+                    mpi_migration_buffers,
                     reporter_context.try_build()?,
                     event_log,
+                    self.migration_interval,
+                    self.progress_interval,
                 )))
             } else {
                 MpiLocalPartition::Parallel(Box::new(MpiParallelPartition::new(
                     ManuallyDrop::into_inner(self.universe),
-                    self.world,
-                    reduce_scope(scope),
-                    &mut mpi_local_continue,
-                    &mut mpi_global_continue,
-                    &mut mpi_local_remaining,
-                    &mut mpi_migration_buffers,
+                    mpi_local_global_continue,
+                    mpi_local_remaining,
+                    mpi_migration_buffers,
                     event_log,
+                    self.migration_interval,
+                    self.progress_interval,
                 )))
             };
 
@@ -193,29 +247,37 @@ impl Partitioning for MpiPartitioning {
     }
 }
 
-fn reduce_scope<'s, 'p: 's>(scope: &'s LocalScope<'p>) -> &'s LocalScope<'s> {
-    // Safety: 'p outlives 's, so reducing the scope from 'p to 's is safe
-    unsafe { std::mem::transmute(scope) }
-}
-
 #[derive(DeserializeState)]
 #[serde(rename = "MpiPartitioning")]
 #[serde(deny_unknown_fields)]
 #[serde(deserialize_state = "NonZeroU32")]
+#[serde(default)]
 #[allow(dead_code)]
 struct MpiPartitioningRaw {
     #[serde(deserialize_state_with = "deserialize_state_mpi_world")]
-    #[serde(default)]
     world: Option<NonZeroU32>,
+    #[serde(alias = "migration")]
+    #[serde(with = "humantime_serde")]
+    migration_interval: Duration,
+    #[serde(alias = "progress")]
+    #[serde(with = "humantime_serde")]
+    progress_interval: Duration,
 }
 
-fn deserialize_state_mpi_world<'de, D>(
+impl Default for MpiPartitioningRaw {
+    fn default() -> Self {
+        Self {
+            world: None,
+            migration_interval: MpiPartitioning::MPI_DEFAULT_MIGRATION_INTERVAL,
+            progress_interval: MpiPartitioning::MPI_DEFAULT_PROGRESS_INTERVAL,
+        }
+    }
+}
+
+fn deserialize_state_mpi_world<'de, D: Deserializer<'de>>(
     mpi_world: &mut NonZeroU32,
     deserializer: D,
-) -> Result<Option<NonZeroU32>, D::Error>
-where
-    D: Deserializer<'de>,
-{
+) -> Result<Option<NonZeroU32>, D::Error> {
     let maybe_world = Option::<NonZeroU32>::deserialize(deserializer)?;
 
     match maybe_world {

--- a/necsim/partitioning/mpi/src/partition/parallel.rs
+++ b/necsim/partitioning/mpi/src/partition/parallel.rs
@@ -96,7 +96,7 @@ impl<'p, R: Reporter> MpiParallelPartition<'p, R> {
             recorder,
             migration_interval,
             progress_interval,
-            _marker: PhantomData,
+            _marker: PhantomData::<(&'p (), R)>,
         }
     }
 }

--- a/necsim/partitioning/mpi/src/partition/parallel.rs
+++ b/necsim/partitioning/mpi/src/partition/parallel.rs
@@ -203,7 +203,7 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiParallelPartition<'p, R> {
                 // Check if the prior send request has finished
                 //  and clear the buffer if it has finished
                 if let Some(emigration_buffer) =
-                    self.mpi_migration_buffers[rank_index].get_data_mut()
+                    self.mpi_migration_buffers[rank_index].test_for_data_mut()
                 {
                     emigration_buffer.clear();
                 }
@@ -309,7 +309,7 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiParallelPartition<'p, R> {
         self.communicated_since_last_barrier = communicated_since_last_barrier;
 
         // Wait if voting is ongoing or at least one partition voted to wait
-        let should_wait = match self.mpi_local_global_wait.get_data_mut() {
+        let should_wait = match self.mpi_local_global_wait.test_for_data_mut() {
             Some((_local_wait, global_wait)) => *global_wait,
             None => true,
         };
@@ -361,7 +361,7 @@ impl<'p, R: Reporter> Reporter for MpiParallelPartition<'p, R> {
     });
 
     impl_report!(progress(&mut self, remaining: MaybeUsed<R::ReportProgress>) {
-        if self.mpi_local_remaining.get_data().map_or(false, |local_remaining| *local_remaining == *remaining) {
+        if self.mpi_local_remaining.test_for_data_mut().map_or(false, |local_remaining| *local_remaining == *remaining) {
             return;
         }
 

--- a/necsim/partitioning/mpi/src/partition/parallel.rs
+++ b/necsim/partitioning/mpi/src/partition/parallel.rs
@@ -37,7 +37,7 @@ use crate::{
 pub struct MpiParallelPartition<'p, R: Reporter> {
     _universe: Universe,
     world: SystemCommunicator,
-    mpi_local_global_continue: DataOrRequest<'p, (bool, bool)>,
+    mpi_local_global_wait: DataOrRequest<'p, (bool, bool)>,
     mpi_local_remaining: DataOrRequest<'p, u64>,
     mpi_migration_buffers: Box<[DataOrRequest<'p, Vec<MigratingLineage>>]>,
     migration_buffers: Box<[Vec<MigratingLineage>]>,
@@ -60,7 +60,7 @@ impl<'p, R: Reporter> MpiParallelPartition<'p, R> {
     #[must_use]
     pub(crate) fn new(
         universe: Universe,
-        mpi_local_global_continue: DataOrRequest<'p, (bool, bool)>,
+        mpi_local_global_wait: DataOrRequest<'p, (bool, bool)>,
         mpi_local_remaining: DataOrRequest<'p, u64>,
         mpi_migration_buffers: Box<[DataOrRequest<'p, Vec<MigratingLineage>>]>,
         mut recorder: EventLogRecorder,
@@ -82,7 +82,7 @@ impl<'p, R: Reporter> MpiParallelPartition<'p, R> {
         Self {
             _universe: universe,
             world,
-            mpi_local_global_continue,
+            mpi_local_global_wait,
             mpi_local_remaining,
             mpi_migration_buffers,
             migration_buffers: migration_buffers.into_boxed_slice(),
@@ -292,27 +292,27 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiParallelPartition<'p, R> {
         let mut communicated_since_last_barrier = self.communicated_since_last_barrier;
 
         // Create a new termination attempt if the last one failed
-        // Wait if at least one partition votes to wait
-        let should_wait = self.mpi_local_global_continue.request_if_data_then_access(
-            |(local_continue, global_continue), scope| {
-                *local_continue = communicated_since_last_barrier;
+        self.mpi_local_global_wait
+            .request_if_data(|(local_wait, global_wait), scope| {
+                *local_wait = communicated_since_last_barrier;
                 communicated_since_last_barrier = false;
-                *global_continue = false;
+                *global_wait = false;
 
                 world.immediate_all_reduce_into(
                     scope,
-                    local_continue,
-                    global_continue,
+                    local_wait,
+                    global_wait,
                     SystemOperation::logical_or(),
                 )
-            },
-            |local_global_continue| match local_global_continue {
-                Some((_local_continue, global_continue)) => *global_continue,
-                None => true,
-            },
-        );
+            });
 
         self.communicated_since_last_barrier = communicated_since_last_barrier;
+
+        // Wait if voting is ongoing or at least one partition voted to wait
+        let should_wait = match self.mpi_local_global_wait.get_data_mut() {
+            Some((_local_wait, global_wait)) => *global_wait,
+            None => true,
+        };
 
         should_wait
     }
@@ -366,7 +366,7 @@ impl<'p, R: Reporter> Reporter for MpiParallelPartition<'p, R> {
         }
 
         // Only send progress if there is no ongoing continue barrier request
-        if self.mpi_local_global_continue.get_data().is_some() {
+        if self.mpi_local_global_wait.get_data().is_some() {
             let now = Instant::now();
 
             if now.duration_since(self.last_report_time) >= self.progress_interval {

--- a/necsim/partitioning/mpi/src/partition/parallel.rs
+++ b/necsim/partitioning/mpi/src/partition/parallel.rs
@@ -98,13 +98,6 @@ impl<'p, R: Reporter> MpiParallelPartition<'p, R> {
         #[allow(clippy::cast_sign_loss)]
         let world_size = world.size() as usize;
 
-        /*let mut mpi_migration_buffers = Vec::with_capacity(world_size);
-        mpi_migration_buffers.resize_with(world_size, Vec::new);
-
-        unsafe {
-            MPI_MIGRATION_BUFFERS = mpi_migration_buffers;
-        }*/
-
         let mut migration_buffers = Vec::with_capacity(world_size);
         migration_buffers.resize_with(world_size, Vec::new);
 
@@ -210,16 +203,9 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiParallelPartition<'p, R> {
                     immigration_buffer.reserve(number_immigrants);
                     immigration_buffer.set_len(receive_start + number_immigrants);
 
-                    // Safety: `MpiMigratingLineage` is a transparent newtype wrapper around
-                    //         `MigratingLineage`
-                    let immigration_slice: &mut [MpiMigratingLineage] =
-                        std::slice::from_raw_parts_mut(
-                            immigration_buffer
-                                .as_mut_ptr()
-                                .cast::<MpiMigratingLineage>()
-                                .add(receive_start),
-                            number_immigrants,
-                        );
+                    let immigration_slice = MpiMigratingLineage::from_mut_slice(
+                        &mut immigration_buffer[receive_start..],
+                    );
 
                     msg.matched_receive_into(immigration_slice);
                 }
@@ -258,18 +244,14 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiParallelPartition<'p, R> {
                     // MPI cannot terminate in this round since this partition gave up work
                     self.communicated_since_last_barrier = true;
 
-                    let local_emigration_buffer = &mut self.mpi_migration_buffers[rank_index];
+                    // Safety: emigration requests barrier protects from mutability conflicts
+                    let local_emigration_buffer =
+                        unsafe { &mut *(&mut self.mpi_migration_buffers[rank_index] as *mut _) };
 
                     std::mem::swap(emigration_buffer, local_emigration_buffer);
 
-                    // Safety: `MpiMigratingLineage` is a transparent newtype wrapper around
-                    //         `MigratingLineage`
-                    let local_emigration_slice: &[MpiMigratingLineage] = unsafe {
-                        std::slice::from_raw_parts(
-                            local_emigration_buffer.as_ptr().cast(),
-                            local_emigration_buffer.len(),
-                        )
-                    };
+                    let local_emigration_slice =
+                        MpiMigratingLineage::from_slice(local_emigration_buffer);
 
                     #[allow(clippy::cast_possible_wrap)]
                     let receiver_process = self.world.process_at_rank(rank as i32);

--- a/necsim/partitioning/mpi/src/partition/root.rs
+++ b/necsim/partitioning/mpi/src/partition/root.rs
@@ -219,22 +219,30 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
                 }
             {
                 // Check if the prior send request has finished
-                self.mpi_migration_buffers[rank_index].test_if_request(|_| ());
+                //  and clear the buffer if it has finished
+                if let Some(emigration_buffer) =
+                    self.mpi_migration_buffers[rank_index].get_data_mut()
+                {
+                    emigration_buffer.clear();
+                }
 
                 let emigration_buffer = &mut self.migration_buffers[rank_index];
 
                 if !emigration_buffer.is_empty() {
-                    self.last_migration_times[rank_index] = now;
-
-                    // MPI cannot terminate in this round since this partition gave up work
-                    self.communicated_since_last_barrier = true;
-
                     #[allow(clippy::cast_possible_wrap)]
                     let receiver_process = self.world.process_at_rank(rank as i32);
+
+                    let mut last_migration_time = self.last_migration_times[rank_index];
+                    let mut communicated_since_last_barrier = self.communicated_since_last_barrier;
 
                     // Send a new non-empty request iff the prior one has finished
                     self.mpi_migration_buffers[rank_index].request_if_data(
                         |mpi_emigration_buffer, scope| {
+                            last_migration_time = now;
+
+                            // MPI cannot terminate in this round since this partition gave up work
+                            communicated_since_last_barrier = true;
+
                             // Any prior send request has already finished
                             mpi_emigration_buffer.clear();
 
@@ -247,6 +255,9 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
                             )
                         },
                     );
+
+                    self.last_migration_times[rank_index] = last_migration_time;
+                    self.communicated_since_last_barrier = communicated_since_last_barrier;
                 }
             }
         }
@@ -290,7 +301,7 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
         // This partition can only terminate if all emigrations have been
         //  sent and acknowledged (request finished + empty buffers)
         for buffer in self.mpi_migration_buffers.iter() {
-            if !buffer.check(|buffer| buffer.map_or(false, Vec::is_empty)) {
+            if !buffer.get_data().map_or(false, Vec::is_empty) {
                 return true;
             }
         }
@@ -301,7 +312,7 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
 
         // Create a new termination attempt if the last one failed
         // Wait if at least one partition votes to wait
-        let should_wait = self.mpi_local_global_continue.request_if_data_then_test(
+        let should_wait = self.mpi_local_global_continue.request_if_data_then_access(
             |(local_continue, global_continue), scope| {
                 *local_continue = communicated_since_last_barrier;
                 communicated_since_last_barrier = false;

--- a/necsim/partitioning/mpi/src/partition/root.rs
+++ b/necsim/partitioning/mpi/src/partition/root.rs
@@ -221,7 +221,7 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
                 // Check if the prior send request has finished
                 //  and clear the buffer if it has finished
                 if let Some(emigration_buffer) =
-                    self.mpi_migration_buffers[rank_index].get_data_mut()
+                    self.mpi_migration_buffers[rank_index].test_for_data_mut()
                 {
                     emigration_buffer.clear();
                 }
@@ -327,7 +327,7 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
         self.communicated_since_last_barrier = communicated_since_last_barrier;
 
         // Wait if voting is ongoing or at least one partition voted to wait
-        let should_wait = match self.mpi_local_global_wait.get_data_mut() {
+        let should_wait = match self.mpi_local_global_wait.test_for_data_mut() {
             Some((_local_wait, global_wait)) => {
                 let should_wait = *global_wait;
 

--- a/necsim/partitioning/mpi/src/partition/root.rs
+++ b/necsim/partitioning/mpi/src/partition/root.rs
@@ -114,7 +114,7 @@ impl<'p, R: Reporter> MpiRootPartition<'p, R> {
             finalised: false,
             migration_interval,
             progress_interval,
-            _marker: PhantomData,
+            _marker: PhantomData::<&'p ()>,
         }
     }
 }

--- a/necsim/partitioning/mpi/src/partition/root.rs
+++ b/necsim/partitioning/mpi/src/partition/root.rs
@@ -11,7 +11,6 @@ use mpi::{
     datatype::Equivalence,
     environment::Universe,
     point_to_point::{Destination, Source},
-    request::{CancelGuard, LocalScope, Request},
     topology::{Communicator, SystemCommunicator},
 };
 
@@ -30,27 +29,27 @@ use necsim_partitioning_core::{
     iterator::ImmigrantPopIterator, partition::Partition, LocalPartition, MigrationMode,
 };
 
-use crate::MpiPartitioning;
-
-use super::utils::{reduce_lexicographic_min_time_rank, MpiMigratingLineage};
+use crate::{
+    partition::utils::{reduce_lexicographic_min_time_rank, MpiMigratingLineage},
+    request::DataOrRequest,
+    MpiPartitioning,
+};
 
 pub struct MpiRootPartition<'p, R: Reporter> {
     _universe: Universe,
     world: SystemCommunicator,
-    scope: &'p LocalScope<'p>,
-    mpi_local_continue: &'p mut bool,
-    mpi_global_continue: &'p mut bool,
-    mpi_migration_buffers: &'p mut [Vec<MigratingLineage>],
-    last_report_time: Instant,
-    all_remaining: Box<[u64]>,
+    mpi_local_global_continue: DataOrRequest<'p, (bool, bool)>,
+    mpi_migration_buffers: Box<[DataOrRequest<'p, Vec<MigratingLineage>>]>,
     migration_buffers: Box<[Vec<MigratingLineage>]>,
+    all_remaining: Box<[u64]>,
+    last_report_time: Instant,
     last_migration_times: Box<[Instant]>,
-    emigration_requests: Box<[Option<Request<'p, &'p LocalScope<'p>>>]>,
+    communicated_since_last_barrier: bool,
     reporter: ManuallyDrop<FilteredReporter<R, False, False, True>>,
     recorder: EventLogRecorder,
-    barrier: Option<Request<'p, &'p LocalScope<'p>>>,
-    communicated_since_last_barrier: bool,
     finalised: bool,
+    migration_interval: Duration,
+    progress_interval: Duration,
     _marker: PhantomData<&'p ()>,
 }
 
@@ -62,6 +61,7 @@ impl<'p, R: Reporter> fmt::Debug for MpiRootPartition<'p, R> {
 
 impl<'p, R: Reporter> Drop for MpiRootPartition<'p, R> {
     fn drop(&mut self) {
+        // Safety: destructor is only run once
         if self.finalised {
             unsafe { ManuallyDrop::take(&mut self.reporter) }.finalise();
         } else {
@@ -69,36 +69,23 @@ impl<'p, R: Reporter> Drop for MpiRootPartition<'p, R> {
                 ManuallyDrop::drop(&mut self.reporter);
             }
         }
-
-        for request in self.emigration_requests.iter_mut() {
-            if let Some(request) = request.take() {
-                std::mem::drop(CancelGuard::from(request));
-            }
-        }
-
-        if let Some(barrier) = self.barrier.take() {
-            std::mem::drop(CancelGuard::from(barrier));
-        }
     }
 }
 
 impl<'p, R: Reporter> MpiRootPartition<'p, R> {
-    const MPI_MIGRATION_WAIT_TIME: Duration = Duration::from_millis(100_u64);
-    const MPI_PROGRESS_WAIT_TIME: Duration = Duration::from_millis(100_u64);
-
     #[must_use]
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         universe: Universe,
-        world: SystemCommunicator,
-        scope: &'p LocalScope<'p>,
-        mpi_local_continue: &'p mut bool,
-        mpi_global_continue: &'p mut bool,
-        mpi_migration_buffers: &'p mut [Vec<MigratingLineage>],
+        mpi_local_global_continue: DataOrRequest<'p, (bool, bool)>,
+        mpi_migration_buffers: Box<[DataOrRequest<'p, Vec<MigratingLineage>>]>,
         reporter: FilteredReporter<R, False, False, True>,
         mut recorder: EventLogRecorder,
+        migration_interval: Duration,
+        progress_interval: Duration,
     ) -> Self {
         recorder.set_event_filter(R::ReportSpeciation::VALUE, R::ReportDispersal::VALUE);
+
+        let world = universe.world();
 
         #[allow(clippy::cast_sign_loss)]
         let world_size = world.size() as usize;
@@ -106,28 +93,27 @@ impl<'p, R: Reporter> MpiRootPartition<'p, R> {
         let mut migration_buffers = Vec::with_capacity(world_size);
         migration_buffers.resize_with(world_size, Vec::new);
 
-        let mut emigration_requests = Vec::with_capacity(world_size);
-        emigration_requests.resize_with(world_size, || None);
-
         let now = Instant::now();
 
         Self {
             _universe: universe,
             world,
-            scope,
-            mpi_local_continue,
-            mpi_global_continue,
+            mpi_local_global_continue,
             mpi_migration_buffers,
-            last_report_time: now.checked_sub(Self::MPI_PROGRESS_WAIT_TIME).unwrap_or(now),
-            all_remaining: vec![0; world_size].into_boxed_slice(),
             migration_buffers: migration_buffers.into_boxed_slice(),
-            last_migration_times: vec![now; world_size].into_boxed_slice(),
-            emigration_requests: emigration_requests.into_boxed_slice(),
+            all_remaining: vec![0; world_size].into_boxed_slice(),
+            last_report_time: now.checked_sub(progress_interval).unwrap_or(now),
+            last_migration_times: vec![
+                now.checked_sub(migration_interval).unwrap_or(now);
+                world_size
+            ]
+            .into_boxed_slice(),
+            communicated_since_last_barrier: false,
             reporter: ManuallyDrop::new(reporter),
             recorder,
-            barrier: None,
-            communicated_since_last_barrier: false,
             finalised: false,
+            migration_interval,
+            progress_interval,
             _marker: PhantomData,
         }
     }
@@ -177,12 +163,12 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
 
         let now = Instant::now();
 
-        // Receive incomming immigrating lineages
+        // Receive incoming immigrating lineages
         if match immigration_mode {
             MigrationMode::Force => true,
             MigrationMode::Default => {
                 now.duration_since(self.last_migration_times[self_rank_index])
-                    >= Self::MPI_MIGRATION_WAIT_TIME
+                    >= self.migration_interval
             },
             MigrationMode::Hold => false,
         } {
@@ -192,7 +178,7 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
 
             let any_process = self.world.any_process();
 
-            // Probe MPI to receive
+            // Probe MPI to receive immigrating lineages
             while let Some((msg, status)) =
                 any_process.immediate_matched_probe_with_tag(MpiPartitioning::MPI_MIGRATION_TAG)
             {
@@ -227,47 +213,40 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
                     MigrationMode::Force => true,
                     MigrationMode::Default => {
                         now.duration_since(self.last_migration_times[rank_index])
-                            >= Self::MPI_PROGRESS_WAIT_TIME
+                            >= self.migration_interval
                     },
                     MigrationMode::Hold => false,
                 }
             {
                 // Check if the prior send request has finished
-                if let Some(request) = self.emigration_requests[rank_index].take() {
-                    if let Err(request) = request.test() {
-                        self.emigration_requests[rank_index] = Some(request);
-                    } else {
-                        self.mpi_migration_buffers[rank_index].clear();
-                    }
-                }
+                self.mpi_migration_buffers[rank_index].test_if_request(|_| ());
 
                 let emigration_buffer = &mut self.migration_buffers[rank_index];
 
-                // Send a new non-empty request iff the prior one has finished
-                if self.emigration_requests[rank_index].is_none() && !emigration_buffer.is_empty() {
+                if !emigration_buffer.is_empty() {
                     self.last_migration_times[rank_index] = now;
 
                     // MPI cannot terminate in this round since this partition gave up work
                     self.communicated_since_last_barrier = true;
 
-                    // Safety: emigration requests barrier protects from mutability conflicts
-                    let local_emigration_buffer =
-                        unsafe { &mut *(&mut self.mpi_migration_buffers[rank_index] as *mut _) };
-
-                    std::mem::swap(emigration_buffer, local_emigration_buffer);
-
-                    let local_emigration_slice =
-                        MpiMigratingLineage::from_slice(local_emigration_buffer);
-
                     #[allow(clippy::cast_possible_wrap)]
                     let receiver_process = self.world.process_at_rank(rank as i32);
 
-                    self.emigration_requests[rank_index] =
-                        Some(receiver_process.immediate_synchronous_send_with_tag(
-                            self.scope,
-                            local_emigration_slice,
-                            MpiPartitioning::MPI_MIGRATION_TAG,
-                        ));
+                    // Send a new non-empty request iff the prior one has finished
+                    self.mpi_migration_buffers[rank_index].request_if_data(
+                        |mpi_emigration_buffer, scope| {
+                            // Any prior send request has already finished
+                            mpi_emigration_buffer.clear();
+
+                            std::mem::swap(emigration_buffer, mpi_emigration_buffer);
+
+                            receiver_process.immediate_synchronous_send_with_tag(
+                                scope,
+                                MpiMigratingLineage::from_slice(mpi_emigration_buffer),
+                                MpiPartitioning::MPI_MIGRATION_TAG,
+                            )
+                        },
+                    );
                 }
             }
         }
@@ -307,52 +286,54 @@ impl<'p, R: Reporter> LocalPartition<'p, R> for MpiRootPartition<'p, R> {
                 return true;
             }
         }
-        for request in self.emigration_requests.iter() {
-            if request.is_some() {
-                return true;
-            }
-        }
+
+        // This partition can only terminate if all emigrations have been
+        //  sent and acknowledged (request finished + empty buffers)
         for buffer in self.mpi_migration_buffers.iter() {
-            if !buffer.is_empty() {
+            if !buffer.check(|buffer| buffer.map_or(false, Vec::is_empty)) {
                 return true;
             }
         }
+
+        let world = &self.world;
+        let mut communicated_since_last_barrier = self.communicated_since_last_barrier;
+        let mut should_check_progress = false;
 
         // Create a new termination attempt if the last one failed
-        let barrier = self.barrier.take().unwrap_or_else(|| {
-            // Safety: the barrier protects from mutability conflicts
-            let local_continue: &'p mut bool = unsafe { &mut *(self.mpi_local_continue as *mut _) };
-            let global_continue: &'p mut bool =
-                unsafe { &mut *(self.mpi_global_continue as *mut _) };
+        // Wait if at least one partition votes to wait
+        let should_wait = self.mpi_local_global_continue.request_if_data_then_test(
+            |(local_continue, global_continue), scope| {
+                *local_continue = communicated_since_last_barrier;
+                communicated_since_last_barrier = false;
+                *global_continue = false;
 
-            *local_continue = self.communicated_since_last_barrier;
-            self.communicated_since_last_barrier = false;
-            *global_continue = false;
-
-            self.world.immediate_all_reduce_into(
-                self.scope,
-                local_continue,
-                global_continue,
-                SystemOperation::logical_or(),
-            )
-        });
-
-        match barrier.test() {
-            Ok(_) => {
-                if !*self.mpi_global_continue {
-                    let remaining = self.all_remaining[self.get_partition().rank() as usize];
-
-                    self.report_progress(&remaining.into());
-                }
-
-                *self.mpi_global_continue
+                world.immediate_all_reduce_into(
+                    scope,
+                    local_continue,
+                    global_continue,
+                    SystemOperation::logical_or(),
+                )
             },
-            Err(barrier) => {
-                self.barrier = Some(barrier);
+            |local_global_continue| match local_global_continue {
+                Some((_local_continue, global_continue)) => {
+                    should_check_progress = true;
 
-                true
+                    *global_continue
+                },
+                None => true,
             },
+        );
+
+        self.communicated_since_last_barrier = communicated_since_last_barrier;
+
+        // Check for pending progress updates from other partitions
+        if should_check_progress {
+            let remaining = self.all_remaining[self.get_partition().rank() as usize];
+
+            self.report_progress(&remaining.into());
         }
+
+        should_wait
     }
 
     fn reduce_global_time_steps(
@@ -414,7 +395,7 @@ impl<'p, R: Reporter> Reporter for MpiRootPartition<'p, R> {
     impl_report!(progress(&mut self, remaining: MaybeUsed<R::ReportProgress>) {
         let now = Instant::now();
 
-        if now.duration_since(self.last_report_time) >= Self::MPI_PROGRESS_WAIT_TIME {
+        if now.duration_since(self.last_report_time) >= self.progress_interval {
             self.last_report_time = now;
 
             self.all_remaining[MpiPartitioning::ROOT_RANK as usize] = *remaining;

--- a/necsim/partitioning/mpi/src/partition/utils.rs
+++ b/necsim/partitioning/mpi/src/partition/utils.rs
@@ -87,31 +87,22 @@ fn reduce_lexicographic_min_time_rank_inner(local: &TimeRank, accumulator: &mut 
 #[repr(transparent)]
 pub struct MpiMigratingLineage(MigratingLineage);
 
-impl From<MigratingLineage> for MpiMigratingLineage {
-    fn from(
-        MigratingLineage {
-            global_reference,
-            prior_time,
-            event_time,
-            coalescence_rng_sample,
-            dispersal_target,
-            dispersal_origin,
-        }: MigratingLineage,
-    ) -> Self {
-        Self(MigratingLineage {
-            global_reference,
-            prior_time,
-            event_time,
-            coalescence_rng_sample,
-            dispersal_target,
-            dispersal_origin,
-        })
+impl MpiMigratingLineage {
+    pub fn from_slice(slice: &[MigratingLineage]) -> &[MpiMigratingLineage] {
+        // Safety: cast to transparent newtype wrapper
+        unsafe {
+            std::slice::from_raw_parts(slice.as_ptr().cast::<MpiMigratingLineage>(), slice.len())
+        }
     }
-}
 
-impl From<MpiMigratingLineage> for MigratingLineage {
-    fn from(lineage: MpiMigratingLineage) -> Self {
-        lineage.0
+    pub fn from_mut_slice(slice: &mut [MigratingLineage]) -> &mut [MpiMigratingLineage] {
+        // Safety: cast to transparent newtype wrapper
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                slice.as_mut_ptr().cast::<MpiMigratingLineage>(),
+                slice.len(),
+            )
+        }
     }
 }
 

--- a/necsim/partitioning/mpi/src/request.rs
+++ b/necsim/partitioning/mpi/src/request.rs
@@ -1,0 +1,95 @@
+use mpi::request::{CancelGuard, LocalScope, Request};
+
+#[allow(clippy::module_name_repetitions)]
+pub struct DataOrRequest<'a, T: ?Sized> {
+    value: &'a mut T,
+    scope: &'a LocalScope<'a>,
+    request: Option<Request<'a, &'a LocalScope<'a>>>,
+}
+
+impl<'a, T: ?Sized> DataOrRequest<'a, T> {
+    #[must_use]
+    pub fn new(value: &'a mut T, scope: &'a LocalScope<'a>) -> Self {
+        Self {
+            value,
+            scope,
+            request: None,
+        }
+    }
+
+    pub fn test_if_request<S: for<'t> FnOnce(Option<&'t mut T>) -> Q, Q>(
+        &mut self,
+        do_test: S,
+    ) -> Q {
+        match self.request.take().map(Request::test) {
+            Some(Ok(_)) => do_test(Some(self.value)),
+            Some(Err(request)) => {
+                self.request = Some(request);
+                do_test(None)
+            },
+            None => do_test(None),
+        }
+    }
+
+    #[must_use]
+    pub fn request_if_data_then_test<
+        R: for<'r> FnOnce(&'r mut T, &'r LocalScope<'r>) -> Request<'r, &'r LocalScope<'r>>,
+        S: for<'t> FnOnce(Option<&'t mut T>) -> Q,
+        Q,
+    >(
+        &mut self,
+        do_request: R,
+        do_test: S,
+    ) -> Q {
+        let request = self.request.take().unwrap_or_else(|| {
+            let request = do_request(self.value, reduce_scope(self.scope));
+
+            // Safety: upgrade of request scope back to the scope 'a
+            unsafe { std::mem::transmute(request) }
+        });
+
+        match request.test() {
+            Ok(_) => do_test(Some(self.value)),
+            Err(request) => {
+                self.request = Some(request);
+                do_test(None)
+            },
+        }
+    }
+
+    #[allow(clippy::let_unit_value)]
+    pub fn request_if_data<
+        R: for<'r> FnOnce(&'r mut T, &'r LocalScope<'r>) -> Request<'r, &'r LocalScope<'r>>,
+    >(
+        &mut self,
+        do_request: R,
+    ) {
+        let _: () = self.request_if_data_then_test(do_request, |_| ());
+    }
+
+    #[must_use]
+    pub fn check<C: for<'c> FnOnce(Option<&'c T>) -> Q, Q>(&self, do_check: C) -> Q {
+        match &self.request {
+            None => do_check(Some(self.value)),
+            Some(_) => do_check(None),
+        }
+    }
+
+    #[must_use]
+    pub fn is_request(&self) -> bool {
+        self.request.is_some()
+    }
+}
+
+impl<'a, T: ?Sized> Drop for DataOrRequest<'a, T> {
+    fn drop(&mut self) {
+        if let Some(request) = self.request.take() {
+            std::mem::drop(CancelGuard::from(request));
+        }
+    }
+}
+
+pub fn reduce_scope<'s, 'p: 's>(scope: &'s LocalScope<'p>) -> &'s LocalScope<'s> {
+    // Safety: 'p outlives 's, so reducing the scope from 'p to 's is safe
+    unsafe { std::mem::transmute(scope) }
+}

--- a/necsim/partitioning/mpi/src/request.rs
+++ b/necsim/partitioning/mpi/src/request.rs
@@ -26,7 +26,7 @@ impl<'a, T: ?Sized> DataOrRequest<'a, T> {
     }
 
     #[must_use]
-    pub fn get_data_mut(&mut self) -> Option<&mut T> {
+    pub fn test_for_data_mut(&mut self) -> Option<&mut T> {
         match self.request.take().map(Request::test) {
             None | Some(Ok(_)) => Some(self.value),
             Some(Err(request)) => {

--- a/necsim/partitioning/mpi/src/request.rs
+++ b/necsim/partitioning/mpi/src/request.rs
@@ -17,42 +17,22 @@ impl<'a, T: ?Sized> DataOrRequest<'a, T> {
         }
     }
 
-    pub fn test_if_request<S: for<'t> FnOnce(Option<&'t mut T>) -> Q, Q>(
-        &mut self,
-        do_test: S,
-    ) -> Q {
-        match self.request.take().map(Request::test) {
-            Some(Ok(_)) => do_test(Some(self.value)),
-            Some(Err(request)) => {
-                self.request = Some(request);
-                do_test(None)
-            },
-            None => do_test(None),
+    #[must_use]
+    pub fn get_data(&self) -> Option<&T> {
+        match &self.request {
+            None => Some(self.value),
+            Some(_) => None,
         }
     }
 
     #[must_use]
-    pub fn request_if_data_then_test<
-        R: for<'r> FnOnce(&'r mut T, &'r LocalScope<'r>) -> Request<'r, &'r LocalScope<'r>>,
-        S: for<'t> FnOnce(Option<&'t mut T>) -> Q,
-        Q,
-    >(
-        &mut self,
-        do_request: R,
-        do_test: S,
-    ) -> Q {
-        let request = self.request.take().unwrap_or_else(|| {
-            let request = do_request(self.value, reduce_scope(self.scope));
-
-            // Safety: upgrade of request scope back to the scope 'a
-            unsafe { std::mem::transmute(request) }
-        });
-
-        match request.test() {
-            Ok(_) => do_test(Some(self.value)),
-            Err(request) => {
+    pub fn get_data_mut(&mut self) -> Option<&mut T> {
+        match self.request.take().map(Request::test) {
+            None | Some(Ok(_)) => Some(self.value),
+            Some(Err(request)) => {
                 self.request = Some(request);
-                do_test(None)
+
+                None
             },
         }
     }
@@ -64,20 +44,33 @@ impl<'a, T: ?Sized> DataOrRequest<'a, T> {
         &mut self,
         do_request: R,
     ) {
-        let _: () = self.request_if_data_then_test(do_request, |_| ());
+        let _: () = self.request_if_data_then_access(do_request, |_| ());
     }
 
     #[must_use]
-    pub fn check<C: for<'c> FnOnce(Option<&'c T>) -> Q, Q>(&self, do_check: C) -> Q {
-        match &self.request {
-            None => do_check(Some(self.value)),
-            Some(_) => do_check(None),
+    pub fn request_if_data_then_access<
+        R: for<'r> FnOnce(&'r mut T, &'r LocalScope<'r>) -> Request<'r, &'r LocalScope<'r>>,
+        S: for<'t> FnOnce(Option<&'t mut T>) -> Q,
+        Q,
+    >(
+        &mut self,
+        do_request: R,
+        do_access: S,
+    ) -> Q {
+        let request = self.request.take().unwrap_or_else(|| {
+            let request = do_request(self.value, reduce_scope(self.scope));
+
+            // Safety: upgrade of request scope back to the scope 'a
+            unsafe { std::mem::transmute(request) }
+        });
+
+        match request.test() {
+            Ok(_) => do_access(Some(self.value)),
+            Err(request) => {
+                self.request = Some(request);
+                do_access(None)
+            },
         }
-    }
-
-    #[must_use]
-    pub fn is_request(&self) -> bool {
-        self.request.is_some()
     }
 }
 

--- a/necsim/plugins/core/src/import/combinator.rs
+++ b/necsim/plugins/core/src/import/combinator.rs
@@ -154,49 +154,49 @@ impl FromIterator<ReporterPlugin> for AnyReporterPluginVec {
             (false, false, false) => {
                 Self::IgnoreSpeciationIgnoreDispersalIgnoreProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(False, False, False)>,
                 })
             },
             (false, false, true) => {
                 Self::IgnoreSpeciationIgnoreDispersalReportProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(False, False, True)>,
                 })
             },
             (false, true, false) => {
                 Self::IgnoreSpeciationReportDispersalIgnoreProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(False, True, False)>,
                 })
             },
             (false, true, true) => {
                 Self::IgnoreSpeciationReportDispersalReportProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(False, True, True)>,
                 })
             },
             (true, false, false) => {
                 Self::ReportSpeciationIgnoreDispersalIgnoreProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(True, False, False)>,
                 })
             },
             (true, false, true) => {
                 Self::ReportSpeciationIgnoreDispersalReportProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(True, False, True)>,
                 })
             },
             (true, true, false) => {
                 Self::ReportSpeciationReportDispersalIgnoreProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(True, True, False)>,
                 })
             },
             (true, true, true) => {
                 Self::ReportSpeciationReportDispersalReportProgress(ReporterPluginVec {
                     plugins,
-                    marker: PhantomData,
+                    marker: PhantomData::<(True, True, True)>,
                 })
             },
         }

--- a/rustcoalescence/algorithms/cuda/src/launch.rs
+++ b/rustcoalescence/algorithms/cuda/src/launch.rs
@@ -50,10 +50,11 @@ use crate::{
 
 #[allow(clippy::too_many_lines)]
 pub fn initialise_and_simulate<
+    'p,
     M: MathsCore,
     O: Scenario<M, CudaRng<M, WyHash<M>>>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     I: Iterator<Item = u64>,
     L: CudaLineageStoreSampleInitialiser<M, CudaRng<M, WyHash<M>>, O, Error>,
     Error: From<CudaError>,

--- a/rustcoalescence/algorithms/cuda/src/launch.rs
+++ b/rustcoalescence/algorithms/cuda/src/launch.rs
@@ -237,7 +237,7 @@ where
                 .chain(passthrough.into_iter())
                 .collect(),
             rng: simulation.rng_mut().clone(),
-            marker: PhantomData,
+            marker: PhantomData::<M>,
         }),
     }
 }

--- a/rustcoalescence/algorithms/cuda/src/lib.rs
+++ b/rustcoalescence/algorithms/cuda/src/lib.rs
@@ -288,7 +288,7 @@ where
     type LineageStore = IndependentLineageStore<M, O::Habitat>;
     type Rng = CudaRng<M, WyHash<M>>;
 
-    fn get_effective_partition(args: &Self::Arguments, _local_partition: &P) -> Partition {
+    fn get_logical_partition(args: &Self::Arguments, _local_partition: &P) -> Partition {
         match &args.parallelism_mode {
             ParallelismMode::Monolithic(_) => Partition::monolithic(),
             ParallelismMode::IsolatedIndividuals(IsolatedParallelismMode { partition, .. })

--- a/rustcoalescence/algorithms/cuda/src/lib.rs
+++ b/rustcoalescence/algorithms/cuda/src/lib.rs
@@ -76,8 +76,13 @@ impl AlgorithmDefaults for CudaAlgorithm {
 }
 
 #[allow(clippy::type_complexity)]
-impl<M: MathsCore, O: Scenario<M, CudaRng<M, WyHash<M>>>, R: Reporter, P: LocalPartition<R>>
-    Algorithm<M, O, R, P> for CudaAlgorithm
+impl<
+        'p,
+        M: MathsCore,
+        O: Scenario<M, CudaRng<M, WyHash<M>>>,
+        R: Reporter,
+        P: LocalPartition<'p, R>,
+    > Algorithm<'p, M, O, R, P> for CudaAlgorithm
 where
     O::Habitat: RustToCuda,
     O::DispersalSampler<InMemoryPackedAliasDispersalSampler<M, O::Habitat, CudaRng<M, WyHash<M>>>>:

--- a/rustcoalescence/algorithms/cuda/src/parallelisation/monolithic.rs
+++ b/rustcoalescence/algorithms/cuda/src/parallelisation/monolithic.rs
@@ -48,6 +48,7 @@ use rustcoalescence_algorithms_cuda_gpu_kernel::SimulatableKernel;
 #[allow(clippy::type_complexity, clippy::too_many_lines)]
 pub fn simulate<
     'l,
+    'p,
     M: MathsCore,
     H: Habitat<M> + RustToCuda,
     G: PrimeableRng<M> + RustToCuda,
@@ -63,7 +64,7 @@ pub fn simulate<
     A: SingularActiveLineageSampler<M, H, G, R, S, X, D, C, T, N, E, I>
         + RustToCuda,
     P: Reporter,
-    L: LocalPartition<P>,
+    L: LocalPartition<'p, P>,
     LI: IntoIterator<Item = Lineage>,
 >(
     simulation: &mut Simulation<M, H, G, R, S, X, D, C, T, N, E, I, A>,
@@ -104,8 +105,8 @@ pub fn simulate<
         E,
         I,
         A,
-        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportSpeciation,
-        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportDispersal,
+        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, 'p, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportSpeciation,
+        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, 'p, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportDispersal,
     >: SimulatableKernel<
         M,
         H,
@@ -120,8 +121,8 @@ pub fn simulate<
         E,
         I,
         A,
-        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportSpeciation,
-        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportDispersal,
+        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, 'p, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportSpeciation,
+        <<WaterLevelReporterStrategy as WaterLevelReporterConstructor<'l, 'p, L::IsLive, P, L>>::WaterLevelReporter as Reporter>::ReportDispersal,
     >,
 {
     let mut slow_lineages = lineages

--- a/rustcoalescence/algorithms/gillespie/src/arguments.rs
+++ b/rustcoalescence/algorithms/gillespie/src/arguments.rs
@@ -7,16 +7,16 @@ use necsim_partitioning_core::{partition::Partition, LocalPartition};
 
 #[derive(Serialize, Debug)]
 #[allow(clippy::module_name_repetitions)]
-pub struct MonolithicArguments {
+pub struct GillespieArguments {
     pub parallelism_mode: ParallelismMode,
 }
 
-impl<'de> DeserializeState<'de, Partition> for MonolithicArguments {
+impl<'de> DeserializeState<'de, Partition> for GillespieArguments {
     fn deserialize_state<D>(partition: &mut Partition, deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::de::Deserializer<'de>,
     {
-        let raw = MonolithicArgumentsRaw::deserialize_state(partition, deserializer)?;
+        let raw = GillespieArgumentsRaw::deserialize_state(partition, deserializer)?;
 
         let parallelism_mode = match raw.parallelism_mode {
             Some(parallelism_mode) => parallelism_mode,
@@ -29,14 +29,15 @@ impl<'de> DeserializeState<'de, Partition> for MonolithicArguments {
             },
         };
 
-        Ok(MonolithicArguments { parallelism_mode })
+        Ok(GillespieArguments { parallelism_mode })
     }
 }
 
 #[derive(Default, Debug, DeserializeState)]
 #[serde(default, deny_unknown_fields)]
+#[serde(rename = "GillespieArguments")]
 #[serde(deserialize_state = "Partition")]
-struct MonolithicArgumentsRaw {
+struct GillespieArgumentsRaw {
     #[serde(deserialize_state)]
     parallelism_mode: Option<ParallelismMode>,
 }
@@ -93,8 +94,8 @@ impl<'de> DeserializeState<'de, Partition> for ParallelismMode {
 }
 
 #[must_use]
-pub fn get_effective_monolithic_partition<'p, R: Reporter, P: LocalPartition<'p, R>>(
-    args: &MonolithicArguments,
+pub fn get_gillespie_logical_partition<'p, R: Reporter, P: LocalPartition<'p, R>>(
+    args: &GillespieArguments,
     local_partition: &P,
 ) -> Partition {
     match &args.parallelism_mode {

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/fixup.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/fixup.rs
@@ -115,13 +115,14 @@ where
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: GloballyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/genesis.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/genesis.rs
@@ -63,13 +63,14 @@ where
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: GloballyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/mod.rs
@@ -64,13 +64,14 @@ pub trait EventSkippingLineageStoreSampleInitialiser<
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: GloballyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/resume.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/initialiser/resume.rs
@@ -69,13 +69,14 @@ where
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: GloballyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/launch.rs
@@ -36,11 +36,12 @@ use crate::arguments::{
 
 #[allow(clippy::shadow_unrelated, clippy::too_many_lines)]
 pub fn initialise_and_simulate<
+    'p,
     M: MathsCore,
     G: SplittableRng<M>,
     O: Scenario<M, G, LineageReference = InMemoryLineageReference>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     I: Iterator<Item = u64>,
     L: EventSkippingLineageStoreSampleInitialiser<M, G, O, Error>,
     Error,

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/launch.rs
@@ -126,7 +126,7 @@ where
                         .cloned()
                         .collect(),
                     rng: simulation.rng_mut().clone(),
-                    marker: PhantomData,
+                    marker: PhantomData::<M>,
                 }),
             }
         },

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/launch.rs
@@ -31,7 +31,7 @@ use rustcoalescence_scenarios::Scenario;
 
 use super::initialiser::EventSkippingLineageStoreSampleInitialiser;
 use crate::arguments::{
-    AveragingParallelismMode, MonolithicArguments, OptimisticParallelismMode, ParallelismMode,
+    AveragingParallelismMode, GillespieArguments, OptimisticParallelismMode, ParallelismMode,
 };
 
 #[allow(clippy::shadow_unrelated, clippy::too_many_lines)]
@@ -46,7 +46,7 @@ pub fn initialise_and_simulate<
     L: EventSkippingLineageStoreSampleInitialiser<M, G, O, Error>,
     Error,
 >(
-    args: MonolithicArguments,
+    args: GillespieArguments,
     rng: G,
     scenario: O,
     pre_sampler: OriginPreSampler<M, I>,

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/mod.rs
@@ -12,7 +12,7 @@ use necsim_impls_no_std::cogs::{
     maths::intrinsics::IntrinsicsMathsCore, origin_sampler::pre_sampler::OriginPreSampler,
 };
 use necsim_impls_std::cogs::rng::pcg::Pcg;
-use necsim_partitioning_core::LocalPartition;
+use necsim_partitioning_core::{partition::Partition, LocalPartition};
 
 use rustcoalescence_algorithms::{
     result::{ResumeError, SimulationOutcome},
@@ -21,7 +21,7 @@ use rustcoalescence_algorithms::{
 };
 use rustcoalescence_scenarios::Scenario;
 
-use crate::arguments::MonolithicArguments;
+use crate::arguments::{get_effective_monolithic_partition, MonolithicArguments};
 
 mod initialiser;
 mod launch;
@@ -59,6 +59,10 @@ where
     type LineageReference = InMemoryLineageReference;
     type LineageStore = O::LineageStore<GillespieLineageStore<M, O::Habitat>>;
     type Rng = Pcg<M>;
+
+    fn get_effective_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
+        get_effective_monolithic_partition(args, local_partition)
+    }
 
     #[allow(clippy::shadow_unrelated, clippy::too_many_lines)]
     fn initialise_and_simulate<I: Iterator<Item = u64>>(

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/mod.rs
@@ -44,11 +44,12 @@ impl AlgorithmDefaults for EventSkippingAlgorithm {
 
 #[allow(clippy::type_complexity)]
 impl<
+        'p,
         O: Scenario<M, Pcg<M>, LineageReference = InMemoryLineageReference>,
         R: Reporter,
-        P: LocalPartition<R>,
+        P: LocalPartition<'p, R>,
         M: MathsCore,
-    > Algorithm<M, O, R, P> for EventSkippingAlgorithm
+    > Algorithm<'p, M, O, R, P> for EventSkippingAlgorithm
 where
     O::LineageStore<GillespieLineageStore<M, O::Habitat>>:
         GloballyCoherentLineageStore<M, O::Habitat, InMemoryLineageReference>,

--- a/rustcoalescence/algorithms/gillespie/src/event_skipping/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/event_skipping/mod.rs
@@ -21,7 +21,7 @@ use rustcoalescence_algorithms::{
 };
 use rustcoalescence_scenarios::Scenario;
 
-use crate::arguments::{get_effective_monolithic_partition, MonolithicArguments};
+use crate::arguments::{get_gillespie_logical_partition, GillespieArguments};
 
 mod initialiser;
 mod launch;
@@ -34,7 +34,7 @@ use initialiser::{
 pub struct EventSkippingAlgorithm {}
 
 impl AlgorithmParamters for EventSkippingAlgorithm {
-    type Arguments = MonolithicArguments;
+    type Arguments = GillespieArguments;
     type Error = !;
 }
 
@@ -60,8 +60,8 @@ where
     type LineageStore = O::LineageStore<GillespieLineageStore<M, O::Habitat>>;
     type Rng = Pcg<M>;
 
-    fn get_effective_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
-        get_effective_monolithic_partition(args, local_partition)
+    fn get_logical_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
+        get_gillespie_logical_partition(args, local_partition)
     }
 
     #[allow(clippy::shadow_unrelated, clippy::too_many_lines)]

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/fixup.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/fixup.rs
@@ -101,13 +101,14 @@ impl<L: ExactSizeIterator<Item = Lineage>, M: MathsCore, G: RngCore<M>, O: Scena
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/genesis.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/genesis.rs
@@ -44,13 +44,14 @@ impl<M: MathsCore, G: RngCore<M>, O: Scenario<M, G>>
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/mod.rs
@@ -63,13 +63,14 @@ pub trait ClassicalLineageStoreSampleInitialiser<
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/resume.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/initialiser/resume.rs
@@ -50,13 +50,14 @@ impl<L: ExactSizeIterator<Item = Lineage>, M: MathsCore, G: RngCore<M>, O: Scena
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
         X: EmigrationExit<M, O::Habitat, G, R, S>,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/launch.rs
@@ -121,7 +121,7 @@ where
                         .cloned()
                         .collect(),
                     rng: simulation.rng_mut().clone(),
-                    marker: PhantomData,
+                    marker: PhantomData::<M>,
                 }),
             }
         },

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/launch.rs
@@ -36,11 +36,12 @@ use super::initialiser::ClassicalLineageStoreSampleInitialiser;
 
 #[allow(clippy::too_many_lines)]
 pub fn initialise_and_simulate<
+    'p,
     M: MathsCore,
     G: SplittableRng<M>,
     O: Scenario<M, G, LineageReference = InMemoryLineageReference, TurnoverRate = UniformTurnoverRate>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     I: Iterator<Item = u64>,
     L: ClassicalLineageStoreSampleInitialiser<M, G, O, Error>,
     Error,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/launch.rs
@@ -29,7 +29,7 @@ use rustcoalescence_algorithms::result::SimulationOutcome;
 use rustcoalescence_scenarios::Scenario;
 
 use crate::arguments::{
-    AveragingParallelismMode, MonolithicArguments, OptimisticParallelismMode, ParallelismMode,
+    AveragingParallelismMode, GillespieArguments, OptimisticParallelismMode, ParallelismMode,
 };
 
 use super::initialiser::ClassicalLineageStoreSampleInitialiser;
@@ -46,7 +46,7 @@ pub fn initialise_and_simulate<
     L: ClassicalLineageStoreSampleInitialiser<M, G, O, Error>,
     Error,
 >(
-    args: MonolithicArguments,
+    args: GillespieArguments,
     rng: G,
     scenario: O,
     pre_sampler: OriginPreSampler<M, I>,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/classical/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/classical/mod.rs
@@ -32,6 +32,7 @@ use initialiser::{
 // Optimised 'Classical' implementation for the `UniformTurnoverSampler`
 #[allow(clippy::type_complexity)]
 impl<
+        'p,
         O: Scenario<
             M,
             Pcg<M>,
@@ -39,9 +40,9 @@ impl<
             TurnoverRate = UniformTurnoverRate,
         >,
         R: Reporter,
-        P: LocalPartition<R>,
+        P: LocalPartition<'p, R>,
         M: MathsCore,
-    > Algorithm<M, O, R, P> for GillespieAlgorithm
+    > Algorithm<'p, M, O, R, P> for GillespieAlgorithm
 where
     O::LineageStore<ClassicalLineageStore<M, O::Habitat>>:
         LocallyCoherentLineageStore<M, O::Habitat, InMemoryLineageReference>,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/mod.rs
@@ -2,7 +2,7 @@ use necsim_impls_no_std::cogs::maths::intrinsics::IntrinsicsMathsCore;
 
 use rustcoalescence_algorithms::{AlgorithmDefaults, AlgorithmParamters};
 
-use crate::arguments::MonolithicArguments;
+use crate::arguments::GillespieArguments;
 
 mod classical;
 mod turnover;
@@ -11,7 +11,7 @@ mod turnover;
 pub enum GillespieAlgorithm {}
 
 impl AlgorithmParamters for GillespieAlgorithm {
-    type Arguments = MonolithicArguments;
+    type Arguments = GillespieArguments;
     type Error = !;
 }
 

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/fixup.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/fixup.rs
@@ -103,6 +103,7 @@ impl<L: ExactSizeIterator<Item = Lineage>, M: MathsCore, G: RngCore<M>, O: Scena
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
@@ -122,7 +123,7 @@ impl<L: ExactSizeIterator<Item = Lineage>, M: MathsCore, G: RngCore<M>, O: Scena
         >,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/genesis.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/genesis.rs
@@ -60,6 +60,7 @@ impl<M: MathsCore, G: RngCore<M>, O: Scenario<M, G>>
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
@@ -79,7 +80,7 @@ impl<M: MathsCore, G: RngCore<M>, O: Scenario<M, G>>
         >,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/mod.rs
@@ -52,6 +52,7 @@ pub trait GillespieLineageStoreSampleInitialiser<
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
@@ -71,7 +72,7 @@ pub trait GillespieLineageStoreSampleInitialiser<
         >,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/resume.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/initialiser/resume.rs
@@ -66,6 +66,7 @@ impl<L: ExactSizeIterator<Item = Lineage>, M: MathsCore, G: RngCore<M>, O: Scena
 
     fn init<
         'h,
+        'p,
         T: TrustedOriginSampler<'h, M, Habitat = O::Habitat>,
         R: LineageReference<M, O::Habitat>,
         S: LocallyCoherentLineageStore<M, O::Habitat, R>,
@@ -85,7 +86,7 @@ impl<L: ExactSizeIterator<Item = Lineage>, M: MathsCore, G: RngCore<M>, O: Scena
         >,
         I: ImmigrationEntry<M>,
         Q: Reporter,
-        P: LocalPartition<Q>,
+        P: LocalPartition<'p, Q>,
     >(
         self,
         origin_sampler: T,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/launch.rs
@@ -35,11 +35,12 @@ use super::initialiser::GillespieLineageStoreSampleInitialiser;
 
 #[allow(clippy::shadow_unrelated, clippy::too_many_lines)]
 pub fn initialise_and_simulate<
+    'p,
     M: MathsCore,
     G: SplittableRng<M>,
     O: Scenario<M, G, LineageReference = InMemoryLineageReference>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     I: Iterator<Item = u64>,
     L: GillespieLineageStoreSampleInitialiser<M, G, O, Error>,
     Error,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/launch.rs
@@ -121,7 +121,7 @@ where
                         .cloned()
                         .collect(),
                     rng: simulation.rng_mut().clone(),
-                    marker: PhantomData,
+                    marker: PhantomData::<M>,
                 }),
             }
         },

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/launch.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/launch.rs
@@ -28,7 +28,7 @@ use rustcoalescence_algorithms::result::SimulationOutcome;
 use rustcoalescence_scenarios::Scenario;
 
 use crate::arguments::{
-    AveragingParallelismMode, MonolithicArguments, OptimisticParallelismMode, ParallelismMode,
+    AveragingParallelismMode, GillespieArguments, OptimisticParallelismMode, ParallelismMode,
 };
 
 use super::initialiser::GillespieLineageStoreSampleInitialiser;
@@ -45,7 +45,7 @@ pub fn initialise_and_simulate<
     L: GillespieLineageStoreSampleInitialiser<M, G, O, Error>,
     Error,
 >(
-    args: MonolithicArguments,
+    args: GillespieArguments,
     rng: G,
     scenario: O,
     pre_sampler: OriginPreSampler<M, I>,

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/mod.rs
@@ -11,7 +11,7 @@ use necsim_impls_no_std::cogs::{
     origin_sampler::pre_sampler::OriginPreSampler,
 };
 use necsim_impls_std::cogs::rng::pcg::Pcg;
-use necsim_partitioning_core::LocalPartition;
+use necsim_partitioning_core::{partition::Partition, LocalPartition};
 
 use rustcoalescence_algorithms::{
     result::{ResumeError, SimulationOutcome},
@@ -19,6 +19,8 @@ use rustcoalescence_algorithms::{
     Algorithm,
 };
 use rustcoalescence_scenarios::Scenario;
+
+use crate::arguments::get_effective_monolithic_partition;
 
 use super::GillespieAlgorithm;
 
@@ -45,6 +47,10 @@ where
     type LineageReference = InMemoryLineageReference;
     type LineageStore = O::LineageStore<ClassicalLineageStore<M, O::Habitat>>;
     type Rng = Pcg<M>;
+
+    default fn get_effective_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
+        get_effective_monolithic_partition(args, local_partition)
+    }
 
     #[allow(clippy::shadow_unrelated, clippy::too_many_lines)]
     default fn initialise_and_simulate<I: Iterator<Item = u64>>(

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/mod.rs
@@ -20,7 +20,7 @@ use rustcoalescence_algorithms::{
 };
 use rustcoalescence_scenarios::Scenario;
 
-use crate::arguments::get_effective_monolithic_partition;
+use crate::arguments::get_gillespie_logical_partition;
 
 use super::GillespieAlgorithm;
 
@@ -48,8 +48,8 @@ where
     type LineageStore = O::LineageStore<ClassicalLineageStore<M, O::Habitat>>;
     type Rng = Pcg<M>;
 
-    default fn get_effective_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
-        get_effective_monolithic_partition(args, local_partition)
+    default fn get_logical_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
+        get_gillespie_logical_partition(args, local_partition)
     }
 
     #[allow(clippy::shadow_unrelated, clippy::too_many_lines)]

--- a/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/mod.rs
+++ b/rustcoalescence/algorithms/gillespie/src/gillespie/turnover/mod.rs
@@ -32,11 +32,12 @@ use initialiser::{
 // Default 'Gillespie' implementation for any turnover sampler
 #[allow(clippy::type_complexity)]
 impl<
+        'p,
         O: Scenario<M, Pcg<M>, LineageReference = InMemoryLineageReference>,
         R: Reporter,
-        P: LocalPartition<R>,
+        P: LocalPartition<'p, R>,
         M: MathsCore,
-    > Algorithm<M, O, R, P> for GillespieAlgorithm
+    > Algorithm<'p, M, O, R, P> for GillespieAlgorithm
 where
     O::LineageStore<ClassicalLineageStore<M, O::Habitat>>:
         LocallyCoherentLineageStore<M, O::Habitat, InMemoryLineageReference>,

--- a/rustcoalescence/algorithms/independent/src/launch.rs
+++ b/rustcoalescence/algorithms/independent/src/launch.rs
@@ -159,7 +159,7 @@ pub fn initialise_and_simulate<
                         .chain(passthrough.into_iter())
                         .collect(),
                     rng: simulation.rng_mut().clone(),
-                    marker: PhantomData,
+                    marker: PhantomData::<M>,
                 }),
             }
         },

--- a/rustcoalescence/algorithms/independent/src/launch.rs
+++ b/rustcoalescence/algorithms/independent/src/launch.rs
@@ -45,11 +45,12 @@ use crate::{
 
 #[allow(clippy::too_many_lines)]
 pub fn initialise_and_simulate<
+    'p,
     M: MathsCore,
     G: PrimeableRng<M>,
     O: Scenario<M, G>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
     I: Iterator<Item = u64>,
     L: IndependentLineageStoreSampleInitialiser<M, G, O, Error>,
     Error,

--- a/rustcoalescence/algorithms/independent/src/lib.rs
+++ b/rustcoalescence/algorithms/independent/src/lib.rs
@@ -54,7 +54,7 @@ impl<'p, O: Scenario<M, WyHash<M>>, R: Reporter, P: LocalPartition<'p, R>, M: Ma
     type LineageStore = IndependentLineageStore<M, O::Habitat>;
     type Rng = WyHash<M>;
 
-    fn get_effective_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
+    fn get_logical_partition(args: &Self::Arguments, local_partition: &P) -> Partition {
         match &args.parallelism_mode {
             ParallelismMode::Monolithic(_) => Partition::monolithic(),
             ParallelismMode::IsolatedIndividuals(IsolatedParallelismMode { partition, .. })

--- a/rustcoalescence/algorithms/independent/src/lib.rs
+++ b/rustcoalescence/algorithms/independent/src/lib.rs
@@ -47,8 +47,8 @@ impl AlgorithmDefaults for IndependentAlgorithm {
 }
 
 #[allow(clippy::type_complexity)]
-impl<O: Scenario<M, WyHash<M>>, R: Reporter, P: LocalPartition<R>, M: MathsCore>
-    Algorithm<M, O, R, P> for IndependentAlgorithm
+impl<'p, O: Scenario<M, WyHash<M>>, R: Reporter, P: LocalPartition<'p, R>, M: MathsCore>
+    Algorithm<'p, M, O, R, P> for IndependentAlgorithm
 {
     type LineageReference = GlobalLineageReference;
     type LineageStore = IndependentLineageStore<M, O::Habitat>;

--- a/rustcoalescence/algorithms/src/lib.rs
+++ b/rustcoalescence/algorithms/src/lib.rs
@@ -42,7 +42,7 @@ pub trait Algorithm<
     type LineageReference: LineageReference<M, O::Habitat>;
     type LineageStore: LineageStore<M, O::Habitat, Self::LineageReference>;
 
-    fn get_effective_partition(args: &Self::Arguments, local_partition: &P) -> Partition;
+    fn get_logical_partition(args: &Self::Arguments, local_partition: &P) -> Partition;
 
     /// # Errors
     ///

--- a/rustcoalescence/algorithms/src/lib.rs
+++ b/rustcoalescence/algorithms/src/lib.rs
@@ -30,8 +30,13 @@ pub trait AlgorithmDefaults {
     type MathsCore: MathsCore;
 }
 
-pub trait Algorithm<M: MathsCore, O: Scenario<M, Self::Rng>, R: Reporter, P: LocalPartition<R>>:
-    Sized + AlgorithmParamters + AlgorithmDefaults
+pub trait Algorithm<
+    'p,
+    M: MathsCore,
+    O: Scenario<M, Self::Rng>,
+    R: Reporter,
+    P: LocalPartition<'p, R>,
+>: Sized + AlgorithmParamters + AlgorithmDefaults
 {
     type Rng: RngCore<M>;
     type LineageReference: LineageReference<M, O::Habitat>;

--- a/rustcoalescence/algorithms/src/lib.rs
+++ b/rustcoalescence/algorithms/src/lib.rs
@@ -11,7 +11,7 @@ use necsim_core::{
 use necsim_core_bond::{NonNegativeF64, PositiveF64};
 
 use necsim_impls_no_std::cogs::origin_sampler::pre_sampler::OriginPreSampler;
-use necsim_partitioning_core::LocalPartition;
+use necsim_partitioning_core::{partition::Partition, LocalPartition};
 
 use rustcoalescence_scenarios::Scenario;
 
@@ -41,6 +41,8 @@ pub trait Algorithm<
     type Rng: RngCore<M>;
     type LineageReference: LineageReference<M, O::Habitat>;
     type LineageStore: LineageStore<M, O::Habitat, Self::LineageReference>;
+
+    fn get_effective_partition(args: &Self::Arguments, local_partition: &P) -> Partition;
 
     /// # Errors
     ///

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/algorithm_scenario.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/algorithm_scenario.rs
@@ -102,7 +102,7 @@ macro_rules! match_scenario_algorithm {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(super) fn dispatch<R: Reporter, P: LocalPartition<R>>(
+pub(super) fn dispatch<'p, R: Reporter, P: LocalPartition<'p, R>>(
     local_partition: P,
 
     speciation_probability_per_generation: PositiveUnitF64,

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/info.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/info.rs
@@ -21,11 +21,12 @@ use super::{super::super::BufferingSimulateArgsBuilder, launch};
 #[allow(dead_code)]
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn dispatch<
+    'p,
     M: MathsCore,
-    A: Algorithm<M, O, R, P>,
+    A: Algorithm<'p, M, O, R, P>,
     O: Scenario<M, A::Rng>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
 >(
     algorithm_args: A::Arguments,
     rng: A::Rng,

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/info.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/info.rs
@@ -68,12 +68,23 @@ where
     }
     info!("{}", resume_pause);
 
-    if local_partition.get_partition().size().get() <= 1 {
-        info!("The simulation will be run in monolithic mode.");
+    let logical_partition = A::get_logical_partition(&algorithm_args, &local_partition);
+    if logical_partition.size().get() <= 1 {
+        info!("The scenario will be simulated as one monolithic partition.");
     } else {
         info!(
-            "The simulation will be distributed across {} partitions.",
-            local_partition.get_partition().size().get()
+            "The scenario will be simulated across {} logical partitions.",
+            logical_partition.size()
+        );
+    }
+
+    let physical_partition = local_partition.get_partition();
+    if physical_partition.size().get() <= 1 {
+        info!("The simulation will be run on one processing unit.");
+    } else {
+        info!(
+            "The simulation will be distributed across {} processing units.",
+            physical_partition.size()
         );
     }
 

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/launch.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/launch.rs
@@ -12,11 +12,12 @@ use rustcoalescence_scenarios::Scenario;
 use crate::args::config::sample::{Sample, SampleMode, SampleModeRestart, SampleOrigin};
 
 pub(super) fn simulate<
+    'p,
     M: MathsCore,
-    A: Algorithm<M, O, R, P>,
+    A: Algorithm<'p, M, O, R, P>,
     O: Scenario<M, A::Rng>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
 >(
     algorithm_args: A::Arguments,
     rng: A::Rng,

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
@@ -46,7 +46,11 @@ where
     Result<AlgorithmOutcome<M, A::Rng>, A::Error>:
         anyhow::Context<AlgorithmOutcome<M, A::Rng>, A::Error>,
 {
-    let rng: A::Rng = match parse::rng::parse_and_normalise(ron_args, normalised_args)? {
+    let rng: A::Rng = match parse::rng::parse_and_normalise(
+        ron_args,
+        normalised_args,
+        &mut local_partition.get_partition(),
+    )? {
         RngArgs::Seed(seed) => SeedableRng::seed_from_u64(seed),
         RngArgs::Sponge(bytes) => {
             let mut seed = <A::Rng as RngCore<M>>::Seed::default();

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
@@ -25,11 +25,12 @@ use super::{
 };
 
 pub(super) fn dispatch<
+    'p,
     M: MathsCore,
-    A: Algorithm<M, O, R, P>,
+    A: Algorithm<'p, M, O, R, P>,
     O: Scenario<M, A::Rng>,
     R: Reporter,
-    P: LocalPartition<R>,
+    P: LocalPartition<'p, R>,
 >(
     local_partition: P,
 

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
@@ -49,7 +49,7 @@ where
     let rng: A::Rng = match parse::rng::parse_and_normalise(
         ron_args,
         normalised_args,
-        &mut A::get_effective_partition(&algorithm_args, &local_partition),
+        &mut A::get_logical_partition(&algorithm_args, &local_partition),
     )? {
         RngArgs::Seed(seed) => SeedableRng::seed_from_u64(seed),
         RngArgs::Sponge(bytes) => {

--- a/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
+++ b/rustcoalescence/src/cli/simulate/dispatch/valid/rng.rs
@@ -49,7 +49,7 @@ where
     let rng: A::Rng = match parse::rng::parse_and_normalise(
         ron_args,
         normalised_args,
-        &mut local_partition.get_partition(),
+        &mut A::get_effective_partition(&algorithm_args, &local_partition),
     )? {
         RngArgs::Seed(seed) => SeedableRng::seed_from_u64(seed),
         RngArgs::Sponge(bytes) => {

--- a/rustcoalescence/src/cli/simulate/parse/rng.rs
+++ b/rustcoalescence/src/cli/simulate/parse/rng.rs
@@ -1,8 +1,7 @@
-use serde::Deserialize;
-
 use necsim_core::cogs::{MathsCore, RngCore};
+use necsim_partitioning_core::partition::Partition;
 
-use crate::args::{config::rng::Rng, utils::parse::try_parse};
+use crate::args::{config::rng::Rng, utils::parse::try_parse_state};
 
 use super::super::BufferingSimulateArgsBuilder;
 
@@ -10,18 +9,21 @@ use super::super::BufferingSimulateArgsBuilder;
 pub(in super::super) fn parse_and_normalise<M: MathsCore, G: RngCore<M>>(
     ron_args: &str,
     normalised_args: &mut BufferingSimulateArgsBuilder,
+    partition: &mut Partition,
 ) -> anyhow::Result<Rng<M, G>> {
-    let SimulateArgsRngOnly { rng } = try_parse("simulate", ron_args)?;
+    let SimulateArgsRngOnly { rng } = try_parse_state("simulate", ron_args, partition)?;
 
     normalised_args.rng(&rng);
 
     Ok(rng)
 }
 
-#[derive(Deserialize)]
+#[derive(DeserializeState)]
 #[serde(bound = "")]
 #[serde(rename = "Simulate")]
+#[serde(deserialize_state = "Partition")]
 struct SimulateArgsRngOnly<M: MathsCore, G: RngCore<M>> {
     #[serde(alias = "randomness")]
+    #[serde(deserialize_state)]
     rng: Rng<M, G>,
 }

--- a/rustcoalescence/src/main.rs
+++ b/rustcoalescence/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::pedantic)]
 #![feature(unwrap_infallible)]
 #![feature(split_array)]
+#![feature(result_flattening)]
 
 #[macro_use]
 extern crate serde_derive_state;


### PR DESCRIPTION
1st step towards #106 by using a scoped `Partitioning::with_local_partition` entry point. No functionality for internal parallelism is added yet, but the MPI partitioning is updated to make use of the scope, allowing to remove its usage of static muts for MPI state.