### PR TITLE
Refactoring and optimisations

### DIFF
--- a/necsim/core/src/cogs/dispersal_sampler.rs
+++ b/necsim/core/src/cogs/dispersal_sampler.rs
@@ -15,8 +15,8 @@ pub trait DispersalSampler<M: MathsCore, H: Habitat<M>, G: RngCore<M>>:
     crate::cogs::Backup + core::fmt::Debug
 {
     #[must_use]
-    #[debug_requires(habitat.contains(location), "location is inside habitat")]
-    #[debug_ensures(old(habitat).contains(&ret), "target is inside habitat")]
+    #[debug_requires(habitat.is_location_habitable(location), "location is habitable")]
+    #[debug_ensures(old(habitat).is_location_habitable(&ret), "target is habitable")]
     fn sample_dispersal_from_location(
         &self,
         location: &Location,
@@ -33,8 +33,8 @@ pub trait SeparableDispersalSampler<M: MathsCore, H: Habitat<M>, G: RngCore<M>>:
     DispersalSampler<M, H, G>
 {
     #[must_use]
-    #[debug_requires(habitat.contains(location), "location is inside habitat")]
-    #[debug_ensures(old(habitat).contains(&ret), "target is inside habitat")]
+    #[debug_requires(habitat.is_location_habitable(location), "location is habitable")]
+    #[debug_ensures(old(habitat).is_location_habitable(&ret), "target is habitable")]
     #[debug_ensures(&ret != location, "disperses to a different location")]
     fn sample_non_self_dispersal_from_location(
         &self,
@@ -44,7 +44,7 @@ pub trait SeparableDispersalSampler<M: MathsCore, H: Habitat<M>, G: RngCore<M>>:
     ) -> Location;
 
     #[must_use]
-    #[debug_requires(habitat.contains(location), "location is inside habitat")]
+    #[debug_requires(habitat.is_location_habitable(location), "location is habitable")]
     fn get_self_dispersal_probability_at_location(
         &self,
         location: &Location,

--- a/necsim/core/src/cogs/habitat.rs
+++ b/necsim/core/src/cogs/habitat.rs
@@ -22,8 +22,15 @@ pub trait Habitat<M: MathsCore>: crate::cogs::Backup + core::fmt::Debug + Sized 
     fn get_extent(&self) -> &LandscapeExtent;
 
     #[must_use]
-    fn contains(&self, location: &Location) -> bool {
-        self.get_extent().contains(location)
+    fn is_location_habitable(&self, location: &Location) -> bool {
+        self.get_extent().contains(location) && self.get_habitat_at_location(location) > 0_u32
+    }
+
+    #[must_use]
+    fn is_indexed_location_habitable(&self, indexed_location: &IndexedLocation) -> bool {
+        self.get_extent().contains(indexed_location.location())
+            && (indexed_location.index()
+                < self.get_habitat_at_location(indexed_location.location()))
     }
 
     #[must_use]

--- a/necsim/core/src/cogs/lineage_store.rs
+++ b/necsim/core/src/cogs/lineage_store.rs
@@ -32,8 +32,8 @@ pub trait LocallyCoherentLineageStore<M: MathsCore, H: Habitat<M>>:
 {
     #[must_use]
     #[debug_requires(
-        habitat.contains(indexed_location.location()),
-        "indexed location is inside habitat"
+        habitat.is_indexed_location_habitable(indexed_location),
+        "indexed location is habitable"
     )]
     fn get_global_lineage_reference_at_indexed_location(
         &self,
@@ -42,8 +42,8 @@ pub trait LocallyCoherentLineageStore<M: MathsCore, H: Habitat<M>>:
     ) -> Option<&GlobalLineageReference>;
 
     #[debug_requires(
-        habitat.contains(lineage.indexed_location.location()),
-        "indexed location is inside habitat"
+        habitat.is_indexed_location_habitable(&lineage.indexed_location),
+        "indexed location is habitable"
     )]
     #[debug_ensures(self.get_lineage_for_local_reference(
         &ret
@@ -68,9 +68,10 @@ pub trait LocallyCoherentLineageStore<M: MathsCore, H: Habitat<M>>:
     #[debug_requires(self.get_lineage_for_local_reference(
         &reference
     ).is_some(), "lineage is active")]
-    #[debug_ensures(old(habitat).contains(
-        ret.indexed_location.location()
-    ), "prior location is inside habitat")]
+    #[debug_ensures(
+        old(habitat).is_indexed_location_habitable(&ret.indexed_location),
+        "prior indexed location is habitable"
+    )]
     #[debug_ensures(self.get_lineage_for_local_reference(
         &old(unsafe { crate::cogs::Backup::backup_unchecked(&reference) })
     ).is_none(), "lineage was deactivated")]
@@ -104,7 +105,10 @@ pub trait GloballyCoherentLineageStore<M: MathsCore, H: Habitat<M>>:
     fn iter_active_locations(&self, habitat: &H) -> Self::LocationIterator<'_>;
 
     #[must_use]
-    #[debug_requires(habitat.contains(location), "location is inside habitat")]
+    #[debug_requires(
+        habitat.is_location_habitable(location),
+        "location is habitable"
+    )]
     fn get_local_lineage_references_at_location_unordered(
         &self,
         location: &Location,

--- a/necsim/core/src/cogs/speciation_probability.rs
+++ b/necsim/core/src/cogs/speciation_probability.rs
@@ -11,7 +11,10 @@ pub trait SpeciationProbability<M: MathsCore, H: Habitat<M>>:
     crate::cogs::Backup + core::fmt::Debug
 {
     #[must_use]
-    #[debug_requires(habitat.contains(location), "location is inside habitat")]
+    #[debug_requires(
+        habitat.is_location_habitable(location),
+        "location is habitable"
+    )]
     fn get_speciation_probability_at_location(
         &self,
         location: &Location,

--- a/necsim/core/src/cogs/turnover_rate.rs
+++ b/necsim/core/src/cogs/turnover_rate.rs
@@ -11,7 +11,10 @@ pub trait TurnoverRate<M: MathsCore, H: Habitat<M>>:
     crate::cogs::Backup + core::fmt::Debug
 {
     #[must_use]
-    #[debug_requires(habitat.contains(location), "location is inside habitat")]
+    #[debug_requires(
+        habitat.is_location_habitable(location),
+        "location is habitable"
+    )]
     #[debug_ensures(
         ret != 0.0_f64 || habitat.get_habitat_at_location(location) == 0_u32,
         "only returns zero if the location is inhabitable"

--- a/necsim/core/src/landscape/extent.rs
+++ b/necsim/core/src/landscape/extent.rs
@@ -16,11 +16,7 @@ pub struct LandscapeExtent {
 
 impl LandscapeExtent {
     #[must_use]
-    #[debug_ensures(ret.x() == x, "stores x")]
-    #[debug_ensures(ret.y() == y, "stores y")]
-    #[debug_ensures(ret.width() == width, "stores width")]
-    #[debug_ensures(ret.height() == height, "stores height")]
-    pub fn new(x: u32, y: u32, width: OffByOneU32, height: OffByOneU32) -> Self {
+    pub const fn new(x: u32, y: u32, width: OffByOneU32, height: OffByOneU32) -> Self {
         Self {
             x,
             y,
@@ -30,27 +26,27 @@ impl LandscapeExtent {
     }
 
     #[must_use]
-    pub fn x(&self) -> u32 {
+    pub const fn x(&self) -> u32 {
         self.x
     }
 
     #[must_use]
-    pub fn y(&self) -> u32 {
+    pub const fn y(&self) -> u32 {
         self.y
     }
 
     #[must_use]
-    pub fn width(&self) -> OffByOneU32 {
+    pub const fn width(&self) -> OffByOneU32 {
         self.width
     }
 
     #[must_use]
-    pub fn height(&self) -> OffByOneU32 {
+    pub const fn height(&self) -> OffByOneU32 {
         self.height
     }
 
     #[must_use]
-    pub fn contains(&self, location: &Location) -> bool {
+    pub const fn contains(&self, location: &Location) -> bool {
         location.x() >= self.x
             && location.x() <= self.width.add_incl(self.x)
             && location.y() >= self.y

--- a/necsim/core/src/landscape/location.rs
+++ b/necsim/core/src/landscape/location.rs
@@ -22,19 +22,17 @@ impl Backup for Location {
 
 impl Location {
     #[must_use]
-    #[debug_ensures(ret.x() == x, "stores x")]
-    #[debug_ensures(ret.y() == y, "stores y")]
-    pub fn new(x: u32, y: u32) -> Self {
+    pub const fn new(x: u32, y: u32) -> Self {
         Self { x, y }
     }
 
     #[must_use]
-    pub fn x(&self) -> u32 {
+    pub const fn x(&self) -> u32 {
         self.x
     }
 
     #[must_use]
-    pub fn y(&self) -> u32 {
+    pub const fn y(&self) -> u32 {
         self.y
     }
 }
@@ -58,22 +56,17 @@ pub struct IndexedLocation {
 
 impl IndexedLocation {
     #[must_use]
-    #[debug_ensures(
-        ret.location.x() == old(location.x()) && ret.location.y() == old(location.y()),
-        "stores location"
-    )]
-    #[debug_ensures(ret.index() == index, "stores index")]
-    pub fn new(location: Location, index: u32) -> Self {
+    pub const fn new(location: Location, index: u32) -> Self {
         Self { location, index }
     }
 
     #[must_use]
-    pub fn location(&self) -> &Location {
+    pub const fn location(&self) -> &Location {
         &self.location
     }
 
     #[must_use]
-    pub fn index(&self) -> u32 {
+    pub const fn index(&self) -> u32 {
         self.index
     }
 }

--- a/necsim/core/src/landscape/location.rs
+++ b/necsim/core/src/landscape/location.rs
@@ -1,6 +1,4 @@
-use core::num::NonZeroU32;
-
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use crate::cogs::Backup;
 
@@ -47,8 +45,6 @@ impl From<IndexedLocation> for Location {
     }
 }
 
-// IndexedLocation uses a NonZeroU32 index internally to enable same-size
-//  Option optimisation
 #[derive(
     Eq, PartialEq, PartialOrd, Ord, Clone, Hash, Debug, Serialize, Deserialize, TypeLayout,
 )]
@@ -57,7 +53,7 @@ impl From<IndexedLocation> for Location {
 #[repr(C)]
 pub struct IndexedLocation {
     location: Location,
-    index: LocationIndex,
+    index: u32,
 }
 
 impl IndexedLocation {
@@ -68,10 +64,7 @@ impl IndexedLocation {
     )]
     #[debug_ensures(ret.index() == index, "stores index")]
     pub fn new(location: Location, index: u32) -> Self {
-        Self {
-            location,
-            index: LocationIndex::new(index),
-        }
+        Self { location, index }
     }
 
     #[must_use]
@@ -81,35 +74,7 @@ impl IndexedLocation {
 
     #[must_use]
     pub fn index(&self) -> u32 {
-        self.index.get()
-    }
-}
-
-#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash, Debug, TypeLayout)]
-#[repr(transparent)]
-struct LocationIndex(NonZeroU32);
-
-impl LocationIndex {
-    fn new(index: u32) -> Self {
-        Self(unsafe { NonZeroU32::new_unchecked(index + 1) })
-    }
-
-    fn get(self) -> u32 {
-        self.0.get() - 1
-    }
-}
-
-impl Serialize for LocationIndex {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        (self.0.get() - 1).serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for LocationIndex {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let inner = u32::deserialize(deserializer)?;
-
-        Ok(Self(unsafe { NonZeroU32::new_unchecked(inner + 1) }))
+        self.index
     }
 }
 
@@ -121,7 +86,7 @@ struct IndexedLocationRaw {
     x: u32,
     y: u32,
     #[serde(alias = "i")]
-    index: LocationIndex,
+    index: u32,
 }
 
 impl From<IndexedLocation> for IndexedLocationRaw {

--- a/necsim/core/src/reporter/impl.rs
+++ b/necsim/core/src/reporter/impl.rs
@@ -2,67 +2,67 @@
 #[allow(clippy::module_name_repetitions)]
 macro_rules! impl_report {
     // Special case: Ignored = MaybeUsed<False>
-    ($(#[$metas:meta])* $target:ident(&mut $this:ident, $value:ident: Ignored) {}) =>
+    ($(#[$metas:meta])* $([$default:tt])? $target:ident(&mut $this:ident, $value:ident: Ignored) {}) =>
     {
         impl_report!{
             $(#[$metas])*
-            $target(&mut $this, $value: MaybeUsed<$crate::reporter::boolean::False>) {}
+            $([$default])? $target(&mut $this, $value: MaybeUsed<$crate::reporter::boolean::False>) {}
         }
     };
     // Special case: Used = MaybeUsed<True>
-    ($(#[$metas:meta])* $target:ident(&mut $this:ident, $value:ident: Used) $code:block) =>
+    ($(#[$metas:meta])* $([$default:tt])? $target:ident(&mut $this:ident, $value:ident: Used) $code:block) =>
     {
         impl_report!{
             $(#[$metas])*
-            $target(&mut $this, $value: MaybeUsed<$crate::reporter::boolean::True>)
+            $([$default])? $target(&mut $this, $value: MaybeUsed<$crate::reporter::boolean::True>)
             $code
         }
     };
     // Dispatch case: MaybeUsed + speciation
-    ($(#[$metas:meta])* speciation(&mut $this:ident, $value:ident: MaybeUsed<$Usage:ty>)
+    ($(#[$metas:meta])* $([$default:tt])? speciation(&mut $this:ident, $value:ident: MaybeUsed<$Usage:ty>)
         $code:block) =>
     {
         impl_report!{
             $(#[$metas])*
-            fn report_speciation(&mut $this, $value: MaybeUsed<
+            $([$default])? fn report_speciation(&mut $this, $value: MaybeUsed<
                 $crate::event::SpeciationEvent, ReportSpeciation = $Usage
             >) $code
         }
     };
     // Dispatch case: MaybeUsed + dispersal
-    ($(#[$metas:meta])* dispersal(&mut $this:ident, $value:ident: MaybeUsed<$Usage:ty>)
+    ($(#[$metas:meta])* $([$default:tt])? dispersal(&mut $this:ident, $value:ident: MaybeUsed<$Usage:ty>)
         $code:block) =>
     {
         impl_report!{
             $(#[$metas])*
-            fn report_dispersal(&mut $this, $value: MaybeUsed<
+            $([$default])? fn report_dispersal(&mut $this, $value: MaybeUsed<
                 $crate::event::DispersalEvent, ReportDispersal = $Usage
             >) $code
         }
     };
     // Dispatch case: MaybeUsed + progress
-    ($(#[$metas:meta])* progress(&mut $this:ident, $value:ident: MaybeUsed<$Usage:ty>)
+    ($(#[$metas:meta])* $([$default:tt])? progress(&mut $this:ident, $value:ident: MaybeUsed<$Usage:ty>)
         $code:block) =>
     {
         impl_report!{
             $(#[$metas])*
-            fn report_progress(&mut $this, $value: MaybeUsed<u64, ReportProgress = $Usage>) $code
+            $([$default])? fn report_progress(&mut $this, $value: MaybeUsed<u64, ReportProgress = $Usage>) $code
         }
     };
     // Impl case: MaybeUsed
-    ($(#[$metas:meta])* fn $target:ident(&mut $this:ident, $value:ident: MaybeUsed<
+    ($(#[$metas:meta])* $([$default:tt])? fn $target:ident(&mut $this:ident, $value:ident: MaybeUsed<
         $EventTy:ty, $UsageIdent:ident = $UsageTy:ty
     >) $code:block) =>
     {
         $(#[$metas])*
-        fn $target(
+        $($default)? fn $target(
             &mut $this,
             $value: &$crate::reporter::used::MaybeUsed<$EventTy, Self::$UsageIdent>,
         ) {
             $value.maybe_use_in(|$value| $code)
         }
 
-        type $UsageIdent = $UsageTy;
+        $($default)? type $UsageIdent = $UsageTy;
     };
 }
 

--- a/necsim/impls/cuda/src/lib.rs
+++ b/necsim/impls/cuda/src/lib.rs
@@ -8,6 +8,8 @@
 #![cfg_attr(target_os = "cuda", feature(asm_experimental_arch))]
 #![cfg_attr(target_os = "cuda", feature(asm_const))]
 #![cfg_attr(target_os = "cuda", feature(const_float_bits_conv))]
+#![allow(incomplete_features)]
+#![feature(specialization)]
 
 extern crate alloc;
 

--- a/necsim/impls/no-std/src/cogs/active_lineage_sampler/alias/individual/mod.rs
+++ b/necsim/impls/no-std/src/cogs/active_lineage_sampler/alias/individual/mod.rs
@@ -90,7 +90,7 @@ impl<
         while let Some(lineage) = origin_sampler.next() {
             if !origin_sampler
                 .habitat()
-                .contains(lineage.indexed_location.location())
+                .is_location_habitable(lineage.indexed_location.location())
             {
                 exceptional_lineages.push(ExceptionalLineage::OutOfHabitat(lineage));
                 continue;

--- a/necsim/impls/no-std/src/cogs/active_lineage_sampler/alias/location/mod.rs
+++ b/necsim/impls/no-std/src/cogs/active_lineage_sampler/alias/location/mod.rs
@@ -109,7 +109,7 @@ impl<
         while let Some(lineage) = origin_sampler.next() {
             if !origin_sampler
                 .habitat()
-                .contains(lineage.indexed_location.location())
+                .is_location_habitable(lineage.indexed_location.location())
             {
                 exceptional_lineages.push(ExceptionalLineage::OutOfHabitat(lineage));
                 continue;

--- a/necsim/impls/no-std/src/cogs/active_lineage_sampler/classical/mod.rs
+++ b/necsim/impls/no-std/src/cogs/active_lineage_sampler/classical/mod.rs
@@ -77,7 +77,7 @@ impl<
         while let Some(lineage) = origin_sampler.next() {
             if !origin_sampler
                 .habitat()
-                .contains(lineage.indexed_location.location())
+                .is_location_habitable(lineage.indexed_location.location())
             {
                 exceptional_lineages.push(ExceptionalLineage::OutOfHabitat(lineage));
                 continue;

--- a/necsim/impls/no-std/src/cogs/active_lineage_sampler/independent/mod.rs
+++ b/necsim/impls/no-std/src/cogs/active_lineage_sampler/independent/mod.rs
@@ -101,7 +101,7 @@ impl<
         while let Some(lineage) = origin_sampler.next() {
             if !origin_sampler
                 .habitat()
-                .contains(lineage.indexed_location.location())
+                .is_location_habitable(lineage.indexed_location.location())
             {
                 exceptional_lineages.push(ExceptionalLineage::OutOfHabitat(lineage));
                 continue;

--- a/necsim/impls/no-std/src/cogs/coalescence_sampler/independent.rs
+++ b/necsim/impls/no-std/src/cogs/coalescence_sampler/independent.rs
@@ -8,7 +8,10 @@ use necsim_core::{
     lineage::LineageInteraction,
 };
 
-use crate::cogs::lineage_store::independent::IndependentLineageStore;
+use crate::cogs::lineage_store::{
+    coherent::globally::singleton_demes::SingletonDemesHabitat,
+    independent::IndependentLineageStore,
+};
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
@@ -34,19 +37,44 @@ impl<M: MathsCore, H: Habitat<M>> CoalescenceSampler<M, H, IndependentLineageSto
     for IndependentCoalescenceSampler<M, H>
 {
     #[must_use]
-    #[debug_ensures(ret.1 == LineageInteraction::Maybe, "always reports maybe")]
-    fn sample_interaction_at_location(
+    // #[debug_ensures(ret.1 == LineageInteraction::Maybe, "always reports maybe")]
+    default fn sample_interaction_at_location(
         &self,
         location: Location,
         habitat: &H,
         _lineage_store: &IndependentLineageStore<M, H>,
         coalescence_rng_sample: CoalescenceRngSample,
     ) -> (IndexedLocation, LineageInteraction) {
-        let chosen_coalescence_index = coalescence_rng_sample
-            .sample_coalescence_index::<M>(habitat.get_habitat_at_location(&location));
+        let population = habitat.get_habitat_at_location(&location);
+
+        let chosen_coalescence_index =
+            coalescence_rng_sample.sample_coalescence_index::<M>(population);
 
         let indexed_location = IndexedLocation::new(location, chosen_coalescence_index);
 
         (indexed_location, LineageInteraction::Maybe)
+    }
+}
+
+// Specialise for SingletonDemesHabitat as the compiler cannot yet optimise out
+//  the call to `habitat.get_habitat_at_location(&location)`.
+#[contract_trait]
+impl<M: MathsCore, H: SingletonDemesHabitat<M>>
+    CoalescenceSampler<M, H, IndependentLineageStore<M, H>>
+    for IndependentCoalescenceSampler<M, H>
+{
+    #[must_use]
+    #[debug_ensures(ret.1 == LineageInteraction::Maybe, "always reports maybe")]
+    fn sample_interaction_at_location(
+        &self,
+        location: Location,
+        _habitat: &H,
+        _lineage_store: &IndependentLineageStore<M, H>,
+        _coalescence_rng_sample: CoalescenceRngSample,
+    ) -> (IndexedLocation, LineageInteraction) {
+        (
+            IndexedLocation::new(location, 0_u32),
+            LineageInteraction::Maybe,
+        )
     }
 }

--- a/necsim/impls/no-std/src/cogs/dispersal_sampler/spatially_implicit.rs
+++ b/necsim/impls/no-std/src/cogs/dispersal_sampler/spatially_implicit.rs
@@ -49,13 +49,11 @@ impl<M: MathsCore, G: RngCore<M>> DispersalSampler<M, SpatiallyImplicitHabitat<M
     for SpatiallyImplicitDispersalSampler<M, G>
 {
     #[must_use]
-    #[debug_requires(
-        habitat.local().contains(location) || habitat.meta().contains(location),
-        "location is inside either the local or meta habitat extent"
-    )]
-    #[debug_ensures(habitat.meta().contains(&ret) || if old(habitat.local().contains(location)) {
-        habitat.local().contains(&ret)
-    } else { false }, "target is inside the meta habitat extent, \
+    #[debug_ensures(habitat.meta().get_extent().contains(&ret) || (
+        if old(habitat.local().get_extent().contains(location)) {
+            habitat.local().get_extent().contains(&ret)
+        } else { false }
+    ), "target is inside the meta habitat extent, \
         or -- iff the location was local -- in the local habitat extent"
     )]
     fn sample_dispersal_from_location(
@@ -66,7 +64,9 @@ impl<M: MathsCore, G: RngCore<M>> DispersalSampler<M, SpatiallyImplicitHabitat<M
     ) -> Location {
         use necsim_core::cogs::RngSampler;
 
-        if habitat.local().contains(location) {
+        // By PRE, location must be habitable, i.e. either in the local or the meta
+        //  habitat
+        if habitat.local().get_extent().contains(location) {
             if rng.sample_event(self.local_migration_probability_per_generation.into()) {
                 // Provide a dummpy Location in the meta community to disperse from
                 self.meta.sample_dispersal_from_location(
@@ -93,13 +93,11 @@ impl<M: MathsCore, G: RngCore<M>> SeparableDispersalSampler<M, SpatiallyImplicit
     for SpatiallyImplicitDispersalSampler<M, G>
 {
     #[must_use]
-    #[debug_requires(
-        habitat.local().contains(location) || habitat.meta().contains(location),
-        "location is inside either the local or meta habitat extent"
-    )]
-    #[debug_ensures(habitat.meta().contains(&ret) || if old(habitat.local().contains(location)) {
-        habitat.local().contains(&ret)
-    } else { false }, "target is inside the meta habitat extent, \
+    #[debug_ensures(habitat.meta().get_extent().contains(&ret) || (
+        if old(habitat.local().get_extent().contains(location)) {
+            habitat.local().get_extent().contains(&ret)
+        } else { false }
+    ), "target is inside the meta habitat extent, \
         or -- iff the location was local -- in the local habitat extent"
     )]
     fn sample_non_self_dispersal_from_location(
@@ -110,7 +108,9 @@ impl<M: MathsCore, G: RngCore<M>> SeparableDispersalSampler<M, SpatiallyImplicit
     ) -> Location {
         use necsim_core::cogs::RngSampler;
 
-        if habitat.local().contains(location) {
+        // By PRE, location must be habitable, i.e. either in the local or the meta
+        //  habitat
+        if habitat.local().get_extent().contains(location) {
             if rng.sample_event(self.local_migration_probability_per_generation.into()) {
                 // Provide a dummpy Location in the meta community to disperse from
                 // As the individual is dispersing to a different community,
@@ -134,16 +134,14 @@ impl<M: MathsCore, G: RngCore<M>> SeparableDispersalSampler<M, SpatiallyImplicit
     }
 
     #[must_use]
-    #[debug_requires(
-        habitat.local().contains(location) || habitat.meta().contains(location),
-        "location is inside either the local or meta habitat extent"
-    )]
     fn get_self_dispersal_probability_at_location(
         &self,
         location: &Location,
         habitat: &SpatiallyImplicitHabitat<M>,
     ) -> ClosedUnitF64 {
-        if habitat.local().contains(location) {
+        // By PRE, location must be habitable, i.e. either in the local or the meta
+        //  habitat
+        if habitat.local().get_extent().contains(location) {
             self.local
                 .get_self_dispersal_probability_at_location(location, habitat.local())
                 * ClosedUnitF64::from(self.local_migration_probability_per_generation).one_minus()

--- a/necsim/impls/no-std/src/cogs/dispersal_sampler/wrapping_noise.rs
+++ b/necsim/impls/no-std/src/cogs/dispersal_sampler/wrapping_noise.rs
@@ -95,22 +95,20 @@ impl<M: MathsCore, G: RngCore<M>> SeparableDispersalSampler<M, WrappingNoiseHabi
         location: &Location,
         habitat: &WrappingNoiseHabitat<M>,
     ) -> ClosedUnitF64 {
-        if habitat.get_habitat_at_location(location) == 0 {
-            ClosedUnitF64::zero()
-        } else {
-            let p_self_dispersal = self
-                .inner
-                .get_self_dispersal_probability_at_location(location, habitat.get_inner());
-            let p_out_dispersal = p_self_dispersal.one_minus() * habitat.coverage();
+        // By PRE, the location is habitable, i.e. self-dispersal is possible
 
-            // Safety:
-            // - p_self_dispersal and p_out_dispersal are both in [0, 1]
-            // - a / (a + [0, 1]) = [0, 1]
-            unsafe {
-                ClosedUnitF64::new_unchecked(
-                    p_self_dispersal.get() / (p_self_dispersal.get() + p_out_dispersal.get()),
-                )
-            }
+        let p_self_dispersal = self
+            .inner
+            .get_self_dispersal_probability_at_location(location, habitat.get_inner());
+        let p_out_dispersal = p_self_dispersal.one_minus() * habitat.coverage();
+
+        // Safety:
+        // - p_self_dispersal and p_out_dispersal are both in [0, 1]
+        // - a / (a + [0, 1]) = [0, 1]
+        unsafe {
+            ClosedUnitF64::new_unchecked(
+                p_self_dispersal.get() / (p_self_dispersal.get() + p_out_dispersal.get()),
+            )
         }
     }
 }

--- a/necsim/impls/no-std/src/cogs/event_sampler/tracking.rs
+++ b/necsim/impls/no-std/src/cogs/event_sampler/tracking.rs
@@ -32,15 +32,7 @@ pub struct SpeciationSample {
     speciation_sample: ClosedOpenUnitF64,
     sample_time: PositiveF64,
     sample_location: IndexedLocation,
-    niche: bool, // only serves to enable the same-sized Option
 }
-
-#[allow(dead_code)]
-const EXCESSIVE_OPTION_SPECIATION_SAMPLE_ERROR: [(); 1 - {
-    const ASSERT: bool = core::mem::size_of::<Option<SpeciationSample>>()
-        == core::mem::size_of::<SpeciationSample>();
-    ASSERT
-} as usize] = [];
 
 impl SpeciationSample {
     pub fn update_min(
@@ -56,7 +48,6 @@ impl SpeciationSample {
                     speciation_sample,
                     sample_time,
                     sample_location: sample_location.clone(),
-                    niche: false,
                 });
             },
         };

--- a/necsim/impls/no-std/src/cogs/event_sampler/tracking.rs
+++ b/necsim/impls/no-std/src/cogs/event_sampler/tracking.rs
@@ -32,6 +32,7 @@ pub struct SpeciationSample {
     speciation_sample: ClosedOpenUnitF64,
     sample_time: PositiveF64,
     sample_location: IndexedLocation,
+    niche: bool, // only serves to enable the same-sized Option
 }
 
 #[allow(dead_code)]
@@ -55,6 +56,7 @@ impl SpeciationSample {
                     speciation_sample,
                     sample_time,
                     sample_location: sample_location.clone(),
+                    niche: false,
                 });
             },
         };

--- a/necsim/impls/no-std/src/cogs/habitat/almost_infinite.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/almost_infinite.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 use necsim_core::{
     cogs::{Backup, Habitat, MathsCore, RngCore, UniformlySampleableHabitat},
@@ -8,19 +8,25 @@ use necsim_core_bond::{OffByOneU32, OffByOneU64};
 
 use crate::cogs::lineage_store::coherent::globally::singleton_demes::SingletonDemesHabitat;
 
+const ALMOST_INFINITE_EXTENT: LandscapeExtent =
+    LandscapeExtent::new(0, 0, OffByOneU32::max(), OffByOneU32::max());
+
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug)]
 #[cfg_attr(feature = "cuda", derive(rust_cuda::common::LendRustToCuda))]
 #[cfg_attr(feature = "cuda", cuda(free = "M"))]
 pub struct AlmostInfiniteHabitat<M: MathsCore> {
-    extent: LandscapeExtent,
     marker: PhantomData<M>,
+}
+
+impl<M: MathsCore> fmt::Debug for AlmostInfiniteHabitat<M> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct(stringify!(AlmostInfiniteHabitat)).finish()
+    }
 }
 
 impl<M: MathsCore> Default for AlmostInfiniteHabitat<M> {
     fn default() -> Self {
         Self {
-            extent: LandscapeExtent::new(0_u32, 0_u32, OffByOneU32::max(), OffByOneU32::max()),
             marker: PhantomData::<M>,
         }
     }
@@ -30,7 +36,6 @@ impl<M: MathsCore> Default for AlmostInfiniteHabitat<M> {
 impl<M: MathsCore> Backup for AlmostInfiniteHabitat<M> {
     unsafe fn backup_unchecked(&self) -> Self {
         Self {
-            extent: self.extent.clone(),
             marker: PhantomData::<M>,
         }
     }
@@ -47,7 +52,7 @@ impl<M: MathsCore> Habitat<M> for AlmostInfiniteHabitat<M> {
 
     #[must_use]
     fn get_extent(&self) -> &LandscapeExtent {
-        &self.extent
+        &ALMOST_INFINITE_EXTENT
     }
 
     #[must_use]

--- a/necsim/impls/no-std/src/cogs/habitat/spatially_implicit.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/spatially_implicit.rs
@@ -8,6 +8,9 @@ use necsim_core_bond::{OffByOneU32, OffByOneU64};
 
 use crate::cogs::habitat::non_spatial::NonSpatialHabitat;
 
+const SPATIALLY_IMPLICIT_EXTENT: LandscapeExtent =
+    LandscapeExtent::new(0, 0, OffByOneU32::max(), OffByOneU32::max());
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 #[cfg_attr(feature = "cuda", derive(rust_cuda::common::LendRustToCuda))]
@@ -17,7 +20,6 @@ pub struct SpatiallyImplicitHabitat<M: MathsCore> {
     local: NonSpatialHabitat<M>,
     #[cfg_attr(feature = "cuda", cuda(embed))]
     meta: NonSpatialHabitat<M>,
-    extent: LandscapeExtent,
 }
 
 impl<M: MathsCore> SpatiallyImplicitHabitat<M> {
@@ -47,11 +49,7 @@ impl<M: MathsCore> SpatiallyImplicitHabitat<M> {
             meta_deme,
         );
 
-        Self {
-            extent: LandscapeExtent::new(0, 0, OffByOneU32::max(), OffByOneU32::max()),
-            local,
-            meta,
-        }
+        Self { local, meta }
     }
 
     #[must_use]
@@ -71,7 +69,6 @@ impl<M: MathsCore> Backup for SpatiallyImplicitHabitat<M> {
         Self {
             local: self.local.backup_unchecked(),
             meta: self.meta.backup_unchecked(),
-            extent: self.extent.clone(),
         }
     }
 }
@@ -87,7 +84,7 @@ impl<M: MathsCore> Habitat<M> for SpatiallyImplicitHabitat<M> {
 
     #[must_use]
     fn get_extent(&self) -> &LandscapeExtent {
-        &self.extent
+        &SPATIALLY_IMPLICIT_EXTENT
     }
 
     #[must_use]

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/mod.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/mod.rs
@@ -35,7 +35,6 @@ pub struct WrappingNoiseHabitat<M: MathsCore> {
 impl<M: MathsCore> fmt::Debug for WrappingNoiseHabitat<M> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct(stringify!(WrappingNoiseHabitat))
-            .field("inner", &self.inner)
             .field("coverage", &self.coverage)
             .field("scale", &self.scale)
             .field("persistence", &self.persistence)

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/mod.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/mod.rs
@@ -221,7 +221,7 @@ fn sum_noise_octaves<M: MathsCore>(
     scale: PositiveUnitF64,
     octaves: NonZeroUsize,
 ) -> f64 {
-    const F64_2_31: f64 = (1 << 31) as f64;
+    const F64_2_32: f64 = (u32::MAX as f64) + 1.0_f64;
 
     let mut max_amplitude = 0.0_f64;
     let mut amplitude = 1.0_f64;
@@ -231,11 +231,11 @@ fn sum_noise_octaves<M: MathsCore>(
 
     for _ in 0..octaves.get() {
         let (x, y) = (
-            (f64::from(location.x()) - F64_2_31) * frequency,
-            (f64::from(location.y()) - F64_2_31) * frequency,
+            f64::from(location.x()) * frequency,
+            f64::from(location.y()) * frequency,
         );
 
-        result += noise.eval_2d::<M>(x, y) * amplitude;
+        result += noise.eval_2d::<M>(x, y, F64_2_32 * frequency) * amplitude;
         max_amplitude += amplitude;
         amplitude *= persistence.get();
         frequency *= 2.0_f64;

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/mod.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/mod.rs
@@ -7,6 +7,8 @@
 // OpenSimplex noise implementation vendored from
 // https://github.com/Mapet13/opensimplex_noise_rust
 // by Jakub Sordyl, licensed under the Unlicense
+//
+// Adapted to use MathsCore and support wrapping
 
 use necsim_core_maths::MathsCore;
 
@@ -61,20 +63,6 @@ impl OpenSimplexNoise {
     #[must_use]
     pub fn eval_4d<M: MathsCore>(&self, x: f64, y: f64, z: f64, w: f64, wrap: f64) -> f64 {
         OpenSimplexNoise4D::eval::<M>(Vec4::new(x, y, z, w), &self.perm, wrap)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use necsim_core_maths::IntrinsicsMathsCore;
-
-    use super::OpenSimplexNoise;
-
-    #[test]
-    fn test_wrapping() {
-        let noise = OpenSimplexNoise::new(Some(42));
-
-        let _ = noise.eval_2d::<IntrinsicsMathsCore>((f64::from(u32::MAX) + 1.0_f64)*0.025-100.0, 0.0, (f64::from(u32::MAX) + 1.0_f64) * 0.025);
     }
 }
 

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/mod.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/mod.rs
@@ -57,6 +57,7 @@ impl OpenSimplexNoise {
         OpenSimplexNoise3D::eval::<M>(Vec3::new(x, y, z), &self.perm)
     }
 
+    #[allow(dead_code)]
     #[must_use]
     pub fn eval_4d<M: MathsCore>(&self, x: f64, y: f64, z: f64, w: f64) -> f64 {
         OpenSimplexNoise4D::eval::<M>(Vec4::new(x, y, z, w), &self.perm)

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/mod.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/mod.rs
@@ -47,20 +47,34 @@ impl OpenSimplexNoise {
 
     #[allow(dead_code)]
     #[must_use]
-    pub fn eval_2d<M: MathsCore>(&self, x: f64, y: f64) -> f64 {
-        OpenSimplexNoise2D::eval::<M>(Vec2::new(x, y), &self.perm)
+    pub fn eval_2d<M: MathsCore>(&self, x: f64, y: f64, wrap: f64) -> f64 {
+        OpenSimplexNoise2D::eval::<M>(Vec2::new(x, y), &self.perm, wrap)
     }
 
     #[allow(dead_code)]
     #[must_use]
-    pub fn eval_3d<M: MathsCore>(&self, x: f64, y: f64, z: f64) -> f64 {
-        OpenSimplexNoise3D::eval::<M>(Vec3::new(x, y, z), &self.perm)
+    pub fn eval_3d<M: MathsCore>(&self, x: f64, y: f64, z: f64, wrap: f64) -> f64 {
+        OpenSimplexNoise3D::eval::<M>(Vec3::new(x, y, z), &self.perm, wrap)
     }
 
     #[allow(dead_code)]
     #[must_use]
-    pub fn eval_4d<M: MathsCore>(&self, x: f64, y: f64, z: f64, w: f64) -> f64 {
-        OpenSimplexNoise4D::eval::<M>(Vec4::new(x, y, z, w), &self.perm)
+    pub fn eval_4d<M: MathsCore>(&self, x: f64, y: f64, z: f64, w: f64, wrap: f64) -> f64 {
+        OpenSimplexNoise4D::eval::<M>(Vec4::new(x, y, z, w), &self.perm, wrap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use necsim_core_maths::IntrinsicsMathsCore;
+
+    use super::OpenSimplexNoise;
+
+    #[test]
+    fn test_wrapping() {
+        let noise = OpenSimplexNoise::new(Some(42));
+
+        let _ = noise.eval_2d::<IntrinsicsMathsCore>((f64::from(u32::MAX) + 1.0_f64)*0.025-100.0, 0.0, (f64::from(u32::MAX) + 1.0_f64) * 0.025);
     }
 }
 
@@ -68,8 +82,8 @@ pub trait NoiseEvaluator<T: vector::VecType<f64>> {
     const STRETCH_POINT: T;
     const SQUISH_POINT: T;
 
-    fn eval<M: MathsCore>(point: T, perm: &PermTable) -> f64;
-    fn extrapolate(grid: T, delta: T, perm: &PermTable) -> f64;
+    fn eval<M: MathsCore>(point: T, perm: &PermTable, wrap: f64) -> f64;
+    fn extrapolate<M: MathsCore>(grid: T, delta: T, perm: &PermTable, wrap: f64) -> f64;
 }
 
 fn generate_perm_array(seed: i64) -> PermTable {

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_2d.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_2d.rs
@@ -71,8 +71,7 @@ impl NoiseEvaluator<Vec2<f64>> for OpenSimplexNoise2D {
 }
 
 impl OpenSimplexNoise2D {
-    #[allow(clippy::inline_always)]
-    #[cfg_attr(target_os = "cuda", inline(always))]
+    #[cfg_attr(target_os = "cuda", inline)]
     fn get_value<M: MathsCore>(
         grid: Vec2<f64>,
         origin: Vec2<f64>,

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_3d.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_3d.rs
@@ -44,13 +44,29 @@ impl NoiseEvaluator<Vec3<f64>> for OpenSimplexNoise3D {
     const SQUISH_POINT: Vec3<f64> = Vec3::new(SQUISH, SQUISH, SQUISH);
     const STRETCH_POINT: Vec3<f64> = Vec3::new(STRETCH, STRETCH, STRETCH);
 
-    fn extrapolate(grid: Vec3<f64>, delta: Vec3<f64>, perm: &PermTable) -> f64 {
+    fn extrapolate<M: MathsCore>(
+        grid: Vec3<f64>,
+        delta: Vec3<f64>,
+        perm: &PermTable,
+        wrap: f64,
+    ) -> f64 {
+        let input = (grid + (Self::SQUISH_POINT * grid.sum())).map(|i| {
+            if i >= wrap {
+                i - wrap
+            } else if i < 0.0 {
+                i + wrap
+            } else {
+                i
+            }
+        });
+        let grid = (input + (Self::STRETCH_POINT * input.sum())).map(M::floor);
+
         let point = GRAD_TABLE[Self::get_grad_table_index(grid, perm)];
 
         point.x * delta.x + point.y * delta.y + point.z * delta.z
     }
 
-    fn eval<M: MathsCore>(input: Vec3<f64>, perm: &PermTable) -> f64 {
+    fn eval<M: MathsCore>(input: Vec3<f64>, perm: &PermTable, wrap: f64) -> f64 {
         let stretch: Vec3<f64> = input + (Self::STRETCH_POINT * input.sum());
         let grid = stretch.map(M::floor);
 
@@ -58,18 +74,25 @@ impl NoiseEvaluator<Vec3<f64>> for OpenSimplexNoise3D {
         let ins = stretch - grid;
         let origin = input - squashed;
 
-        Self::get_value(grid, origin, ins, perm)
+        Self::get_value::<M>(grid, origin, ins, perm, wrap)
     }
 }
 
 impl OpenSimplexNoise3D {
-    fn get_value(grid: Vec3<f64>, origin: Vec3<f64>, ins: Vec3<f64>, perm: &PermTable) -> f64 {
+    fn get_value<M: MathsCore>(
+        grid: Vec3<f64>,
+        origin: Vec3<f64>,
+        ins: Vec3<f64>,
+        perm: &PermTable,
+        wrap: f64,
+    ) -> f64 {
         let contribute = |x: f64, y: f64, z: f64| {
-            utils::contribute::<OpenSimplexNoise3D, Vec3<f64>>(
+            utils::contribute::<OpenSimplexNoise3D, Vec3<f64>, M>(
                 Vec3::new(x, y, z),
                 origin,
                 grid,
                 perm,
+                wrap,
             )
         };
 

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_3d.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_3d.rs
@@ -50,16 +50,8 @@ impl NoiseEvaluator<Vec3<f64>> for OpenSimplexNoise3D {
         perm: &PermTable,
         wrap: f64,
     ) -> f64 {
-        let input = (grid + (Self::SQUISH_POINT * grid.sum())).map(|i| {
-            if i >= wrap {
-                i - wrap
-            } else if i < 0.0 {
-                i + wrap
-            } else {
-                i
-            }
-        });
-        let grid = (input + (Self::STRETCH_POINT * input.sum())).map(M::floor);
+        // Wrap the grid to put in the range [0; wrap), then snap to grid points
+        let grid = grid.map(|i| i - M::floor(i / wrap) * wrap).map(M::floor);
 
         let point = GRAD_TABLE[Self::get_grad_table_index(grid, perm)];
 
@@ -67,6 +59,9 @@ impl NoiseEvaluator<Vec3<f64>> for OpenSimplexNoise3D {
     }
 
     fn eval<M: MathsCore>(input: Vec3<f64>, perm: &PermTable, wrap: f64) -> f64 {
+        // Pre-squish the input to allow wrapping in extrapolate
+        let input = input + (Self::SQUISH_POINT * input.sum());
+
         let stretch: Vec3<f64> = input + (Self::STRETCH_POINT * input.sum());
         let grid = stretch.map(M::floor);
 

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_4d.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/open_simplex_noise_4d.rs
@@ -90,16 +90,8 @@ impl NoiseEvaluator<Vec4<f64>> for OpenSimplexNoise4D {
         perm: &PermTable,
         wrap: f64,
     ) -> f64 {
-        let input = (grid + (Self::SQUISH_POINT * grid.sum())).map(|i| {
-            if i >= wrap {
-                i - wrap
-            } else if i < 0.0 {
-                i + wrap
-            } else {
-                i
-            }
-        });
-        let grid = (input + (Self::STRETCH_POINT * input.sum())).map(M::floor);
+        // Wrap the grid to put in the range [0; wrap), then snap to grid points
+        let grid = grid.map(|i| i - M::floor(i / wrap) * wrap).map(M::floor);
 
         let point = GRAD_TABLE[Self::get_grad_table_index(grid, perm)];
 
@@ -107,6 +99,9 @@ impl NoiseEvaluator<Vec4<f64>> for OpenSimplexNoise4D {
     }
 
     fn eval<M: MathsCore>(input: Vec4<f64>, perm: &PermTable, wrap: f64) -> f64 {
+        // Pre-squish the input to allow wrapping in extrapolate
+        let input = input + (Self::SQUISH_POINT * input.sum());
+
         let stretch: Vec4<f64> = input + (Self::STRETCH_POINT * input.sum());
         let grid = stretch.map(M::floor);
 

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/utils.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/utils.rs
@@ -1,10 +1,13 @@
+use necsim_core_maths::MathsCore;
+
 use super::{vector::VecType, NoiseEvaluator, PermTable};
 
-pub fn contribute<NoiseEvaluatorType: NoiseEvaluator<Vec>, Vec: VecType<f64>>(
+pub fn contribute<NoiseEvaluatorType: NoiseEvaluator<Vec>, Vec: VecType<f64>, M: MathsCore>(
     delta: Vec,
     origin: Vec,
     grid: Vec,
     perm: &PermTable,
+    wrap: f64,
 ) -> f64 {
     let shifted: Vec = origin - delta - NoiseEvaluatorType::SQUISH_POINT * delta.sum();
     let attn: f64 = 2.0 - shifted.get_attenuation_factor();
@@ -16,5 +19,5 @@ pub fn contribute<NoiseEvaluatorType: NoiseEvaluator<Vec>, Vec: VecType<f64>>(
     let attn2 = attn * attn;
     let attn4 = attn2 * attn2;
 
-    attn4 * NoiseEvaluatorType::extrapolate(grid + delta, shifted, perm)
+    attn4 * NoiseEvaluatorType::extrapolate::<M>(grid + delta, shifted, perm, wrap)
 }

--- a/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/utils.rs
+++ b/necsim/impls/no-std/src/cogs/habitat/wrapping_noise/opensimplex_noise/utils.rs
@@ -13,5 +13,8 @@ pub fn contribute<NoiseEvaluatorType: NoiseEvaluator<Vec>, Vec: VecType<f64>>(
         return 0.0;
     }
 
-    attn * attn * attn * attn * NoiseEvaluatorType::extrapolate(grid + delta, shifted, perm)
+    let attn2 = attn * attn;
+    let attn4 = attn2 * attn2;
+
+    attn4 * NoiseEvaluatorType::extrapolate(grid + delta, shifted, perm)
 }

--- a/necsim/impls/no-std/src/cogs/origin_sampler/decomposition.rs
+++ b/necsim/impls/no-std/src/cogs/origin_sampler/decomposition.rs
@@ -84,12 +84,7 @@ impl<'d, M: MathsCore, O: UntrustedOriginSampler<'d, M>, D: Decomposition<M, O::
             if !self
                 .origin_sampler
                 .habitat()
-                .contains(lineage.indexed_location.location())
-                || lineage.indexed_location.index()
-                    >= self
-                        .origin_sampler
-                        .habitat()
-                        .get_habitat_at_location(lineage.indexed_location.location())
+                .is_indexed_location_habitable(&lineage.indexed_location)
             {
                 if self.decomposition.get_subdomain().is_root() {
                     return Some(lineage);

--- a/necsim/impls/no-std/src/cogs/speciation_probability/spatially_implicit.rs
+++ b/necsim/impls/no-std/src/cogs/speciation_probability/spatially_implicit.rs
@@ -36,17 +36,15 @@ impl<M: MathsCore> SpeciationProbability<M, SpatiallyImplicitHabitat<M>>
     for SpatiallyImplicitSpeciationProbability
 {
     #[must_use]
-    #[debug_requires(
-        habitat.local().contains(location) || habitat.meta().contains(location),
-        "location is inside either the local or meta habitat extent"
-    )]
     #[inline]
     fn get_speciation_probability_at_location(
         &self,
         location: &Location,
         habitat: &SpatiallyImplicitHabitat<M>,
     ) -> ClosedUnitF64 {
-        if habitat.local().contains(location) {
+        // By PRE, location must be habitable, i.e. either in the local or the meta
+        //  habitat
+        if habitat.local().get_extent().contains(location) {
             ClosedUnitF64::zero()
         } else {
             self.meta_speciation_probability.into()

--- a/necsim/impls/no-std/src/decomposition/mod.rs
+++ b/necsim/impls/no-std/src/decomposition/mod.rs
@@ -14,10 +14,7 @@ pub mod radial;
 pub trait Decomposition<M: MathsCore, H: Habitat<M>>: Backup + Sized + core::fmt::Debug {
     fn get_subdomain(&self) -> Partition;
 
-    #[debug_requires(
-        habitat.contains(location),
-        "location is contained inside habitat"
-    )]
+    #[debug_requires(habitat.is_location_habitable(location), "location is habitable")]
     #[debug_ensures(
         ret < self.get_subdomain().size().get(),
         "subdomain rank is in range [0, self.get_subdomain().size())"

--- a/necsim/plugins/species/src/individual/feather/dataframe.rs
+++ b/necsim/plugins/species/src/individual/feather/dataframe.rs
@@ -118,7 +118,7 @@ impl IndividualSpeciesFeatherReporter {
         let mut parents = Vec::with_capacity(self.origins.len());
 
         for (lineage, origin) in &self.origins {
-            ids.push(unsafe { lineage.clone().into_inner().get() - 2 });
+            ids.push(unsafe { lineage.clone().into_inner() });
 
             xs.push(origin.location().x());
             ys.push(origin.location().y());
@@ -130,8 +130,6 @@ impl IndividualSpeciesFeatherReporter {
                     .unwrap_or(lineage)
                     .clone()
                     .into_inner()
-                    .get()
-                    - 2
             });
         }
 

--- a/necsim/plugins/species/src/individual/feather/mod.rs
+++ b/necsim/plugins/species/src/individual/feather/mod.rs
@@ -12,7 +12,7 @@ use necsim_core::{
     landscape::{IndexedLocation, Location},
     lineage::GlobalLineageReference,
 };
-use necsim_core_bond::{NonNegativeF64, NonZeroOneU64};
+use necsim_core_bond::NonNegativeF64;
 
 use crate::{LastEventState, SpeciesIdentity};
 
@@ -191,19 +191,13 @@ impl<'de> Deserialize<'de> for IndividualSpeciesFeatherReporter {
                     .zip(parents.values_iter())
                     .zip(species.iter())
                 {
-                    let id = unsafe {
-                        GlobalLineageReference::from_inner(NonZeroOneU64::new_unchecked(*id + 2))
-                    };
+                    let id = unsafe { GlobalLineageReference::from_inner(*id) };
 
                     // Populate the individual `origins` lookup
                     self_origins
                         .insert(id.clone(), IndexedLocation::new(Location::new(*x, *y), *i));
 
-                    let parent = unsafe {
-                        GlobalLineageReference::from_inner(NonZeroOneU64::new_unchecked(
-                            *parent + 2,
-                        ))
-                    };
+                    let parent = unsafe { GlobalLineageReference::from_inner(*parent) };
 
                     // Populate the individual `parents` lookup
                     // parent == id -> individual does NOT have a parent

--- a/necsim/plugins/species/src/individual/sqlite/database.rs
+++ b/necsim/plugins/species/src/individual/sqlite/database.rs
@@ -2,7 +2,7 @@ use necsim_core::{
     landscape::{IndexedLocation, Location},
     lineage::GlobalLineageReference,
 };
-use necsim_core_bond::{NonZeroOneU64, PositiveF64};
+use necsim_core_bond::PositiveF64;
 
 use rusqlite::{named_params, types::Value};
 
@@ -240,9 +240,7 @@ impl IndividualSpeciesSQLiteReporter {
             let parent: Option<i64> = row.get("parent")?;
             let species: Option<String> = row.get("species")?;
 
-            let id = unsafe {
-                GlobalLineageReference::from_inner(NonZeroOneU64::new_unchecked(from_i64(id) + 2))
-            };
+            let id = unsafe { GlobalLineageReference::from_inner(from_i64(id)) };
 
             // Populate the individual `origins` lookup
             self.origins.insert(
@@ -251,11 +249,7 @@ impl IndividualSpeciesSQLiteReporter {
             );
 
             if let Some(parent) = parent {
-                let parent = unsafe {
-                    GlobalLineageReference::from_inner(NonZeroOneU64::new_unchecked(
-                        from_i64(parent) + 2,
-                    ))
-                };
+                let parent = unsafe { GlobalLineageReference::from_inner(from_i64(parent)) };
 
                 // Populate the individual `parents` lookup
                 self.parents.insert(id.clone(), parent);
@@ -352,14 +346,14 @@ impl IndividualSpeciesSQLiteReporter {
 
             // Positional parameters boost performance
             insertion.execute(rusqlite::params![
-                /* :id */ to_i64(unsafe { lineage.clone().into_inner().get() - 2 }),
+                /* :id */ to_i64(unsafe { lineage.clone().into_inner() }),
                 /* :x */ to_i32(origin.location().x()),
                 /* :y */ to_i32(origin.location().y()),
                 /* :i */ to_i32(origin.index()),
                 /* :parent */
                 self.parents
                     .get(&lineage)
-                    .map(|parent| to_i64(unsafe { parent.clone().into_inner().get() - 2 })),
+                    .map(|parent| to_i64(unsafe { parent.clone().into_inner() })),
                 /* :species */
                 self.species
                     .get(&ancestor)

--- a/rustcoalescence/algorithms/cuda/src/parallelisation/monolithic.rs
+++ b/rustcoalescence/algorithms/cuda/src/parallelisation/monolithic.rs
@@ -314,7 +314,7 @@ pub fn simulate<
                             }
                         }
 
-                        event_buffer.report_events(&mut proxy);
+                        event_buffer.report_events_unordered(&mut proxy);
 
                         proxy.local_partition().get_reporter().report_progress(
                             &((slow_lineages.len() as u64) + (fast_lineages.len() as u64)).into(),


### PR DESCRIPTION
- strengthened all `Habitat`-derived cog pre-conditions s.t. `Location`s and `IndexedLocation`s must be habitable, not just within bounds
- removed the `IndexedLocation` index hack, use the full `u32` instead
- removed the `GlobalLineageReference` representation hack, use the full `u64` instead
- optimised the `WrappingNoiseHabitat` to use wrapping 2d noise instead of 4d noise
- pulled in a better `EventBuffer` from #230
- changed the `PackedEvent` representation to retain its packed size despite the removed hacks